### PR TITLE
Breakdown long running phase to add requeue logic

### DIFF
--- a/enhancements/annotation-requeue/README.md
+++ b/enhancements/annotation-requeue/README.md
@@ -51,7 +51,7 @@ We propose the following modifications in the function responsible for annotatin
 
 ```
 total := len(allResource)
-annotation := 0
+now := time.Now()
 for i, ns := range allResource() {
     retrieve single resource
     .
@@ -66,9 +66,8 @@ for i, ns := range allResource() {
     .
     .
     .
-    annotation ++
-    if total >= 5 && annotation == total / 5 {
-        t.Requeue = PollReQ
+    if time.Now().Sub(now) == time.Second * 3 {
+        t.Requeue = FastReQ
         return nil
     }
     t.Progress = []string{fmt.Sprintf("%v/%v Namespace labeled", i, total)}    
@@ -78,7 +77,7 @@ for i, ns := range allResource() {
 Changes in task.go file in `AnnotateResource` switch case:
 
 ```
-if t.Requeue != PollReQ {
+if t.Requeue != FastReQ {
     if err = t.next(); err != nil {
         return liberr.Wrap(err)
     }

--- a/enhancements/annotation-requeue/README.md
+++ b/enhancements/annotation-requeue/README.md
@@ -51,7 +51,6 @@ We propose the following modifications in the function responsible for annotatin
 
 ```
 total := len(allResource)
-now := time.Now()
 for i, ns := range allResource() {
     retrieve single resource
     .
@@ -66,12 +65,25 @@ for i, ns := range allResource() {
     .
     .
     .
-    if time.Now().Sub(now) == time.Second * 3 {
-        t.Requeue = FastReQ
+    itemsUpdated ++
+    if itemsUpdated > 50 {
+        t.Progress = []string{fmt.Sprintf("%v/%v Namespace labeled", i, total)}        
         return nil
     }
-    t.Progress = []string{fmt.Sprintf("%v/%v Namespace labeled", i, total)}    
 }
+
+```
+Changes in `annotateStageResources()` function
+```
+itemsUpdate := 0
+// Namespaces
+itemsUpdate, err = t.labelNamespaces(sourceClient, itemsUpdate)
+<...>
+if itemsUpdate > 50 {
+  t.Requeue = FastReQ
+  return nil
+}
+// similar code for all the other resource processing
 
 ```
 Changes in task.go file in `AnnotateResource` switch case:

--- a/enhancements/annotation-requeue/README.md
+++ b/enhancements/annotation-requeue/README.md
@@ -1,33 +1,7 @@
 
----
-title: MTC Progress Reporting Improvements
-authors:
-  - "@pranavgaikwad"
-  - "@JaydipGabani"
-reviewers:
-  - "@jortel"
-  - "@djwhatle"
-  - "@alaypatel07"
-  - "@dymurray"
-approvers:
-  - "@jortel"
-  - "@djwhatle"
-  - "@alaypatel07"
-  - "@dymurray"
-creation-date: 2020-11-03
-last-updated: 2020-11-03
-status: implementable
-see-also:
-  - "N/A" 
-replaces:
-  - "N/A"
-superseded-by:
-  - "N/A"
----
+# Adding Requeue in Long running phase - AnnotateResources
 
-# Adding Requeue in Long running phase like AnnotateResources
-
-The goal of this document is to highlight user experience issues in the current implementation of progress reporting in MTC, and propose improvements in some of the areas for a better user experience. The driving goal of the effort is to ensure that the user has enough information in their hands to understand what exactly is happening in the background of an ongoing migration.
+The goal of this document is to highlight user experience issues in the current implementation of progress reporting in MTC, and propose improvements in some of the areas for a better user experience. The driving goal of the effort is to ensure that the user has enough information in their hands to understand what exactly is happening in the background of an ongoing migration phase AnnotateResources.
 
 ## Release Signoff Checklist
 
@@ -35,7 +9,17 @@ The goal of this document is to highlight user experience issues in the current 
 - [ ] Design details are appropriately documented from clear requirements
 - [ ] Test plan is defined
 
-Currently `AnnotateResource` phase runs for loops to annotate or label resources. Currently this happens in a single reconcile. The whole phase takes few seconds to several minutes depending on the number of resources included in the migration. This can leave user without any sense of progress. This design doc proposes an approach to add `Requeue` logic to such long running phase to update user about the progress while the whole phase is getting processed.
+## Summary 
+
+With the proposed changes, migration controller will periodically halt the process of phase `AnnotateResource` and update `mig_migration` CR and Resume the process on the next reconcile.
+
+## Motivation
+
+Currently `AnnotateResource` phase runs for loops to annotate or label resources. Currently this happens in a single reconcile. The whole phase takes few seconds to several minutes depending on the number of resources included in the migration. This can leave user without any sense of progress. 
+
+## Proposal
+
+This design doc proposes an approach to add `Requeue` logic to such long running phase to update user about the progress while the whole phase is getting processed.
 
 We propose the following modifications in the function responsible for annotating.
 

--- a/enhancements/annotation-requeue/README.md
+++ b/enhancements/annotation-requeue/README.md
@@ -1,18 +1,19 @@
 ---
 title: Adding Requeue in Long running phase - AnnotateResources
 authors:
-  - "@pranavgaikwad"
   - "@JaydipGabani"
 reviewers:
   - "@jortel"
   - "@djwhatle"
   - "@alaypatel07"
   - "@dymurray"
+  - "@pranavgaikwad"
 approvers:
   - "@jortel"
   - "@djwhatle"
   - "@alaypatel07"
   - "@dymurray"
+  - "@pranavgaikwad"
 creation-date: 2020-11-04
 last-updated: 2020-11-04
 status: implementable

--- a/enhancements/annotation-requeue/README.md
+++ b/enhancements/annotation-requeue/README.md
@@ -1,4 +1,39 @@
-### Adding Requeue in Long running phase like AnnotateResources
+
+---
+title: MTC Progress Reporting Improvements
+authors:
+  - "@pranavgaikwad"
+  - "@JaydipGabani"
+reviewers:
+  - "@jortel"
+  - "@djwhatle"
+  - "@alaypatel07"
+  - "@dymurray"
+approvers:
+  - "@jortel"
+  - "@djwhatle"
+  - "@alaypatel07"
+  - "@dymurray"
+creation-date: 2020-11-03
+last-updated: 2020-11-03
+status: implementable
+see-also:
+  - "N/A" 
+replaces:
+  - "N/A"
+superseded-by:
+  - "N/A"
+---
+
+# Adding Requeue in Long running phase like AnnotateResources
+
+The goal of this document is to highlight user experience issues in the current implementation of progress reporting in MTC, and propose improvements in some of the areas for a better user experience. The driving goal of the effort is to ensure that the user has enough information in their hands to understand what exactly is happening in the background of an ongoing migration.
+
+## Release Signoff Checklist
+
+- [x] Enhancement is `implementable`
+- [ ] Design details are appropriately documented from clear requirements
+- [ ] Test plan is defined
 
 Currently `AnnotateResource` phase runs for loops to annotate or label resources. Currently this happens in a single reconcile. The whole phase takes few seconds to several minutes depending on the number of resources included in the migration. This can leave user without any sense of progress. This design doc proposes an approach to add `Requeue` logic to such long running phase to update user about the progress while the whole phase is getting processed.
 

--- a/enhancements/annotation-requeue/README.md
+++ b/enhancements/annotation-requeue/README.md
@@ -74,7 +74,7 @@ for i, ns := range allResource() {
 }
 
 ```
-Changes in task.go file
+Changes in task.go file in `AnnotateResource` switch case:
 
 ```
 if t.Requeue != PollReQ {

--- a/enhancements/annotation-requeue/README.md
+++ b/enhancements/annotation-requeue/README.md
@@ -1,3 +1,28 @@
+---
+title: Adding Requeue in Long running phase - AnnotateResources
+authors:
+  - "@pranavgaikwad"
+  - "@JaydipGabani"
+reviewers:
+  - "@jortel"
+  - "@djwhatle"
+  - "@alaypatel07"
+  - "@dymurray"
+approvers:
+  - "@jortel"
+  - "@djwhatle"
+  - "@alaypatel07"
+  - "@dymurray"
+creation-date: 2020-11-04
+last-updated: 2020-11-04
+status: implementable
+see-also:
+  - "N/A" 
+replaces:
+  - "N/A"
+superseded-by:
+  - "N/A"
+---
 
 # Adding Requeue in Long running phase - AnnotateResources
 

--- a/enhancements/annotation-requeue/README.md
+++ b/enhancements/annotation-requeue/README.md
@@ -1,0 +1,43 @@
+### Adding Requeue in Long running phase like AnnotateResources
+
+Currently `AnnotateResource` phase runs for loops to annotate or label resources. Currently this happens in a single reconcile. The whole phase takes few seconds to several minutes depending on the number of resources included in the migration. This can leave user without any sense of progress. This design doc proposes an approach to add `Requeue` logic to such long running phase to update user about the progress while the whole phase is getting processed.
+
+We propose the following modifications in the function responsible for annotating.
+
+```
+total := len(allResource)
+annotation := 0
+for i, ns := range allResource() {
+    retrieve single resource
+    .
+    .
+    .
+
+    if _, exist := <resource>.GetLabels()[IncludedInStageBackupLabel]; exist {
+			continue
+	}
+
+    set annotations
+    .
+    .
+    .
+    annotation ++
+    if total >= 5 && annotation == total / 5 {
+        t.Requeue = PollReQ
+        return nil
+    }
+    t.Progress = []string{fmt.Sprintf("%v/%v Namespace labeled", i, total)}    
+}
+
+```
+Changes in task.go file
+
+```
+if t.Requeue != PollReQ {
+    if err = t.next(); err != nil {
+        return liberr.Wrap(err)
+    }
+}
+```
+
+The above code will requeue periodically to report progress and then continue the loop to annotate resource. We are checking if label exists or not before hand to make sure every resource gets processed only once.


### PR DESCRIPTION
Proposing to add requeue logic in `AnnotateResource` phase to report progress during the long-running annotations.