### PR TITLE
Application Inventory / Pathfinder / Container Advisor integration

### DIFF
--- a/enhancements/tackle/pathfinder-tca-integration.md
+++ b/enhancements/tackle/pathfinder-tca-integration.md
@@ -1,0 +1,180 @@
+---
+title: pathfinder-tca-integration
+authors:
+  - "@rofrano"
+reviewers:
+  - TBD
+approvers:
+  - TBD
+creation-date: 2022-03-01
+last-updated: 2022-03-01
+status: provisional
+see-also:
+  - ""  
+replaces:
+  - ""
+superseded-by:
+  - ""
+---
+
+# Pathfinder / Tackle Container Advisor Integration
+
+This is the title of the enhancement. Keep it simple and descriptive. A good
+title can help communicate what the enhancement is and should be considered as
+part of any review.
+
+The YAML `title` should be lowercased and spaces/punctuation should be
+replaced with `-`.
+
+To get started with this template:
+1. **Pick a domain.** Find the appropriate domain to discuss your enhancement.
+1. **Make a copy of this template.** Copy this template into the directory for
+   the domain.
+1. **Fill out the "overview" sections.** This includes the Summary and
+   Motivation sections. These should be easy and explain why the community
+   should desire this enhancement.
+1. **Create a PR.** Assign it to folks with expertise in that domain to help
+   sponsor the process.
+1. **Merge at each milestone.** Merge when the design is able to transition to a
+   new status (provisional, implementable, implemented, etc.). View anything
+   marked as `provisional` as an idea worth exploring in the future, but not
+   accepted as ready to execute. Anything marked as `implementable` should
+   clearly communicate how an enhancement is coded up and delivered. If an
+   enhancement describes a new deployment topology or platform, include a
+   logical description for the deployment, and how it handles the unique aspects
+   of the platform. Aim for single topic PRs to keep discussions focused. If you
+   disagree with what is already in a document, open a new PR with suggested
+   changes.
+
+The `Metadata` section above is intended to support the creation of tooling
+around the enhancement process.
+
+## Release Signoff Checklist
+
+- [ ] Enhancement is `implementable`
+- [ ] Design details are appropriately documented from clear requirements
+- [ ] Test plan is defined
+- [ ] User-facing documentation is created
+
+## Open Questions [optional]
+
+None  
+
+## Summary
+
+[Tackle Pathfinder](https://github.com/konveyor/tackle-pathfinder) is a tool for determining what path to take to modernize workloads on Kubernetes. [Tackle Container Advisor](https://github.com/konveyor/tackle-container-advisor) (TCA) is a tool to help standardize technology descriptions and determine if a workload can be run in a container, and if so, what container should be used.
+
+This enhancement proposes to have Pathfinder integrate with Tackle Container Advisor for two purposes:
+
+1. The technology standardization of TCA can be used to take application descriptions and create consistent tags in Pathfinder
+
+2. The output from TCA can be additional input to the report that Pathfinder generates to determine the disposition of a workload in the cloud.
+
+## Motivation
+
+Creating tags and tagging applications can be time consuming and error prone. When tagging a few application it's not a lot of work but when tagging 1000's of applications for an enterprise migration to Kubernetes it can be a daunting task. Many times application descriptions are vague and use inaccurate terms like "rhel, db2, java ee, tomcat". TCA has the ability to turn that string into "RedHat Enterprise Linux, IBM DB2, Java J2EE, Apache Tomcat". These more standardized terms can be used to create tags and then tag applications consistently throughout pathfinder.
+
+A prerequisite to deploying applications on Kubernetes is knowing if the application can be containerized. This is critical input to the pathfinder report yet it is missing. TCA can provide an evaluation to determine if the technologies used by an application can be run in a container and which container to suggest be used when deploying the application. This will help the users of pathfinder determine which workload disposition (i.e., retire, retain, rehost, replatform, refactor, rewrite) to use.
+
+### Goals
+
+- Enhance the capabilities of Tackle Pathfinder with the standardization technology from Tackle Container Advisor for the purpose of generating tags and tagging applications consistently.
+- Enhance the reporting capabilities of Tackle Pathfinder with the container advisory technology from Tackle Container Advisor to recommend which applications can be containerized and which container images to use.
+
+### Non-Goals
+
+- Embedding technologies. This may be the first use case for Tackle having a set of callable services running in Kubernetes that can be called by other tools.
+
+## Proposal
+
+This is where we get down to the nitty gritty of what the proposal actually is.
+
+### Personas / Actors
+
+#### Migration Architect
+
+The Migration Architect is responsible for determining teh disposition of each application with regard to whether it should be retired, retained, rehosted, replatformed, refactored, rewritten.
+
+### User Stories
+
+#### Story 1
+
+**As a** Migration Architect  
+**I need** to be able to easily tag applications with their technologies  
+**So that** I can categorize applications for migration based on the technologies that they use  
+
+#### Story 2
+
+**As a** Migration Architect  
+**I need** to be able to understand which applications can be containerized  
+**So that** I can determine the feasibility of deploying them onto Kubernetes
+
+### Implementation Details/Notes/Constraints [optional]
+
+What are the caveats to the implementation? What are some important details that
+didn't come across above. Go in to as much detail as necessary here. This might
+be a good place to talk about core concepts and how they relate.
+
+### Security, Risks, and Mitigations
+
+**Carefully think through the security implications for this change**
+
+What are the risks of this proposal and how do we mitigate. Think broadly. How
+will this impact the broader OKD ecosystem? Does this work in a managed services
+environment that has many tenants?
+
+How will security be reviewed and by whom? How will UX be reviewed and by whom?
+
+Consider including folks that also work outside your immediate sub-project.
+
+## Design Details
+
+### Test Plan
+
+**Note:** *Section not required until targeted at a release.*
+
+Consider the following in developing a test plan for this enhancement:
+- Will there be e2e and integration tests, in addition to unit tests?
+- How will it be tested in isolation vs with other components?
+
+No need to outline all of the test cases, just the general strategy. Anything
+that would count as tricky in the implementation and anything particularly
+challenging to test should be called out.
+
+All code is expected to have adequate tests (eventually with coverage
+expectations).
+
+### Upgrade / Downgrade Strategy
+
+If applicable, how will the component be upgraded and downgraded? Make sure this
+is in the test plan.
+
+Consider the following in developing an upgrade/downgrade strategy for this
+enhancement:
+- What changes (in invocations, configurations, API use, etc.) is an existing
+  cluster required to make on upgrade in order to...
+  -  keep previous behavior?
+  - make use of the enhancement?
+
+## Implementation History
+
+Major milestones in the life cycle of a proposal should be tracked in `Implementation
+History`.
+
+## Drawbacks
+
+The idea is to find the best form of an argument why this enhancement should _not_ be implemented.
+
+## Alternatives
+
+Similar to the `Drawbacks` section the `Alternatives` section is used to
+highlight and record other possible approaches to delivering the value proposed
+by an enhancement.
+
+## Infrastructure Needed [optional]
+
+Use this section if you need things from the project. Examples include a new
+subproject, repos requested, github details, and/or testing infrastructure.
+
+Listing these here allows the community to get the process for these resources
+started right away.

--- a/enhancements/tackle/pathfinder-tca-integration.md
+++ b/enhancements/tackle/pathfinder-tca-integration.md
@@ -32,11 +32,13 @@ None
 
 ## Summary
 
+This proposal is to integrate the capabilities of Tackle Container Advisor with both the Tackle Application Inventory and Tackle Pathfinder as outlined below.
+
 [Tackle Application Inventory](https://github.com/konveyor/tackle-application-inventory) is a tool for cataloging and tagging applications that are candidates for modernization / migration. [Tackle Pathfinder](https://github.com/konveyor/tackle-pathfinder) is a tool for determining what path to take to modernize workloads on Kubernetes. [Tackle Container Advisor](https://github.com/konveyor/tackle-container-advisor) (TCA) is a tool to help standardize technology descriptions and determine if a workload can be run in a container, and if so, what container should be used.
 
 This enhancement proposes to have Tackle Application Inventory and Tackle Pathfinder integrate with Tackle Container Advisor for two purposes:
 
-1. The standardization technology of Tackle Container Advisor can be used to take application descriptions and create consistent tags in the Application Inventory based on the technology used by the application.
+1. The standardization technology of Tackle Container Advisor can be used to take application technology descriptions and create consistent standardized tags in the Application Inventory, based on the technology used by the application.
 
 2. The containerization recommendations from Tackle Container Advisor can be additional input to the report that Pathfinder generates to determine the disposition of a workload in the cloud by identifying if it is suitable for containerization and if so what container images to choose.
 
@@ -81,13 +83,17 @@ The Migration Architect is responsible for determining teh disposition of each a
 
 ### Implementation Details/Notes/Constraints [optional]
 
-#### Tackle Pathfinder Implementation
-
-The proposed solution for Tackle Pathfinder integration is for TCA to create a Command Line Interface (CLI) that could be invoked as an Add-On to Pathfinder following its add-on architecture. TCA is currently a Python microservice that runs as a service.
-
 #### Tackle Application Inventory Implementation
 
-It is not clear how TCA would integrate with Tackle Application Inventory. I'm not sure if the Application Inventory has similar extensibility as Pathfinder. We will need to do more work in figuring this out.
+The proposed solution for Application Inventory integration is for TCA to create a Command Line Interface (CLI) that could be invoked as an Add-On to the Application Inventory following the Tackle Hub's add-on architecture. TCA is currently a Python microservice that runs as a service in Kubernetes so the easiest thing is for this new CLI to make a REST API call to the TCA service running in the cluster. Alternately we could investigate the CLI running TCA locally but start-up times may prohibit this from being a performant implementation.
+
+One proposal is that the standardization API for Tackle Container Advisor could be invoke during CSV import of application data to the Application Inventory. It would process the technology field and generate tags which would be stored in the Tackle Hub database. These tags could then be verified by the customer before using them to generate containerization recommendations, which would also be stored in the Tackle Hub database.
+
+It is not clear when or how the containerization recommendations would be generated from the Application Inventory, but it should be after the tags have been verified by the customer as being accurate.
+
+#### Tackle Pathfinder Implementation
+
+Pathfinder would use the containerization recommendation stored in te Tackle Hub database, in its report. This would require no changes from TCA. Only Pathfinder would need to modified to see if these recommendations have been generated and then include them in the report that it produces.
 
 ### Security, Risks, and Mitigations
 

--- a/enhancements/tackle/pathfinder-tca-integration.md
+++ b/enhancements/tackle/pathfinder-tca-integration.md
@@ -1,5 +1,5 @@
 ---
-title: pathfinder-tca-integration
+title: app-inv-pathfinder-tca-integration
 authors:
   - "@rofrano"
 reviewers:
@@ -7,7 +7,7 @@ reviewers:
 approvers:
   - TBD
 creation-date: 2022-03-01
-last-updated: 2022-03-01
+last-updated: 2022-03-15
 status: provisional
 see-also:
   - ""  
@@ -17,37 +17,7 @@ superseded-by:
   - ""
 ---
 
-# Pathfinder / Tackle Container Advisor Integration
-
-This is the title of the enhancement. Keep it simple and descriptive. A good
-title can help communicate what the enhancement is and should be considered as
-part of any review.
-
-The YAML `title` should be lowercased and spaces/punctuation should be
-replaced with `-`.
-
-To get started with this template:
-1. **Pick a domain.** Find the appropriate domain to discuss your enhancement.
-1. **Make a copy of this template.** Copy this template into the directory for
-   the domain.
-1. **Fill out the "overview" sections.** This includes the Summary and
-   Motivation sections. These should be easy and explain why the community
-   should desire this enhancement.
-1. **Create a PR.** Assign it to folks with expertise in that domain to help
-   sponsor the process.
-1. **Merge at each milestone.** Merge when the design is able to transition to a
-   new status (provisional, implementable, implemented, etc.). View anything
-   marked as `provisional` as an idea worth exploring in the future, but not
-   accepted as ready to execute. Anything marked as `implementable` should
-   clearly communicate how an enhancement is coded up and delivered. If an
-   enhancement describes a new deployment topology or platform, include a
-   logical description for the deployment, and how it handles the unique aspects
-   of the platform. Aim for single topic PRs to keep discussions focused. If you
-   disagree with what is already in a document, open a new PR with suggested
-   changes.
-
-The `Metadata` section above is intended to support the creation of tooling
-around the enhancement process.
+# App Inventory / Pathfinder / Tackle Container Advisor Integration
 
 ## Release Signoff Checklist
 
@@ -62,28 +32,28 @@ None
 
 ## Summary
 
-[Tackle Pathfinder](https://github.com/konveyor/tackle-pathfinder) is a tool for determining what path to take to modernize workloads on Kubernetes. [Tackle Container Advisor](https://github.com/konveyor/tackle-container-advisor) (TCA) is a tool to help standardize technology descriptions and determine if a workload can be run in a container, and if so, what container should be used.
+[Tackle Application Inventory](https://github.com/konveyor/tackle-application-inventory) is a tool for cataloging and tagging applications that are candidates for modernization / migration. [Tackle Pathfinder](https://github.com/konveyor/tackle-pathfinder) is a tool for determining what path to take to modernize workloads on Kubernetes. [Tackle Container Advisor](https://github.com/konveyor/tackle-container-advisor) (TCA) is a tool to help standardize technology descriptions and determine if a workload can be run in a container, and if so, what container should be used.
 
-This enhancement proposes to have Pathfinder integrate with Tackle Container Advisor for two purposes:
+This enhancement proposes to have Tackle Application Inventory and Tackle Pathfinder integrate with Tackle Container Advisor for two purposes:
 
-1. The technology standardization of TCA can be used to take application descriptions and create consistent tags in Pathfinder
+1. The technology standardization of TCA can be used to take application descriptions and create consistent tags in the Application Inventory
 
-2. The output from TCA can be additional input to the report that Pathfinder generates to determine the disposition of a workload in the cloud.
+2. The output from TCA can be additional input to the report that Pathfinder generates to determine the disposition of a workload in the cloud by identifying if it is suitable for containerization and if so what container images to choose..
 
 ## Motivation
 
-Creating tags and tagging applications can be time consuming and error prone. When tagging a few application it's not a lot of work but when tagging 1000's of applications for an enterprise migration to Kubernetes it can be a daunting task. Many times application descriptions are vague and use inaccurate terms like "rhel, db2, java ee, tomcat". TCA has the ability to turn that string into "RedHat Enterprise Linux, IBM DB2, Java J2EE, Apache Tomcat". These more standardized terms can be used to create tags and then tag applications consistently throughout pathfinder.
+Creating tags and tagging applications can be time consuming and error prone. When tagging a few application it's not a lot of work but when tagging 1000's of applications for an enterprise migration to Kubernetes it can be a daunting task. Many times application descriptions are vague and use inaccurate terms like "rhel, db2, java ee, tomcat". TCA has the ability to turn that string into standardized terms like "RedHat Enterprise Linux, IBM DB2, Java J2EE, Apache Tomcat". These more standardized terms can be used to create tags and then tag applications consistently in the Application Inventory.
 
-A prerequisite to deploying applications on Kubernetes is knowing if the application can be containerized. This is critical input to the pathfinder report yet it is missing. TCA can provide an evaluation to determine if the technologies used by an application can be run in a container and which container to suggest be used when deploying the application. This will help the users of pathfinder determine which workload disposition (i.e., retire, retain, rehost, replatform, refactor, rewrite) to use.
+A prerequisite to deploying applications on Kubernetes is knowing if the application can be containerized. This is critical input to the Pathfinder report yet it is missing. TCA can provide an evaluation to determine if the technologies used by an application can be run in a container and which container to suggest be used when deploying the application. This will help the users of Pathfinder determine which workload disposition (i.e., retire, retain, rehost, replatform, refactor, rewrite) to use.
 
 ### Goals
 
-- Enhance the capabilities of Tackle Pathfinder with the standardization technology from Tackle Container Advisor for the purpose of generating tags and tagging applications consistently.
+- Enhance the capabilities of Tackle Application Inventory with the standardization technology from Tackle Container Advisor for the purpose of generating tags and tagging applications consistently.
 - Enhance the reporting capabilities of Tackle Pathfinder with the container advisory technology from Tackle Container Advisor to recommend which applications can be containerized and which container images to use.
 
 ### Non-Goals
 
-- Embedding technologies. This may be the first use case for Tackle having a set of callable services running in Kubernetes that can be called by other tools.
+- None yet
 
 ## Proposal
 
@@ -111,21 +81,21 @@ The Migration Architect is responsible for determining teh disposition of each a
 
 ### Implementation Details/Notes/Constraints [optional]
 
-What are the caveats to the implementation? What are some important details that
-didn't come across above. Go in to as much detail as necessary here. This might
-be a good place to talk about core concepts and how they relate.
+#### Tackle Pathfinder Implementation
+
+The proposed solution for Tackle Pathfinder integration is for TCA to create a Command Line Interface (CLI) that could be invoked as an Add-On to Pathfinder following it's add-on architecture. TCA is currently a Python microservice that runs as a service.
+
+#### Tackle Application Inventory Implementation
+
+It is not clear how TCA would integrate with Tackle Application Inventory. I'm not sure if the Application Inventory has similar extensibility as Pathfinder. We will need to do more work in figuring this out.
 
 ### Security, Risks, and Mitigations
 
 **Carefully think through the security implications for this change**
 
-What are the risks of this proposal and how do we mitigate. Think broadly. How
-will this impact the broader OKD ecosystem? Does this work in a managed services
-environment that has many tenants?
+Tackle Container Advisor is a stateless microservice. It retains none of the input data that is sent and records none of the output data that is returned.
 
-How will security be reviewed and by whom? How will UX be reviewed and by whom?
-
-Consider including folks that also work outside your immediate sub-project.
+As such it has minimal security implications.
 
 ## Design Details
 
@@ -133,48 +103,23 @@ Consider including folks that also work outside your immediate sub-project.
 
 **Note:** *Section not required until targeted at a release.*
 
-Consider the following in developing a test plan for this enhancement:
-- Will there be e2e and integration tests, in addition to unit tests?
-- How will it be tested in isolation vs with other components?
-
-No need to outline all of the test cases, just the general strategy. Anything
-that would count as tricky in the implementation and anything particularly
-challenging to test should be called out.
-
-All code is expected to have adequate tests (eventually with coverage
-expectations).
+None yet.
 
 ### Upgrade / Downgrade Strategy
 
-If applicable, how will the component be upgraded and downgraded? Make sure this
-is in the test plan.
-
-Consider the following in developing an upgrade/downgrade strategy for this
-enhancement:
-- What changes (in invocations, configurations, API use, etc.) is an existing
-  cluster required to make on upgrade in order to...
-  -  keep previous behavior?
-  - make use of the enhancement?
+None yet.
 
 ## Implementation History
 
-Major milestones in the life cycle of a proposal should be tracked in `Implementation
-History`.
+None yet.
 
 ## Drawbacks
 
-The idea is to find the best form of an argument why this enhancement should _not_ be implemented.
+None yet.
 
 ## Alternatives
 
-Similar to the `Drawbacks` section the `Alternatives` section is used to
-highlight and record other possible approaches to delivering the value proposed
-by an enhancement.
+None yet.
 
 ## Infrastructure Needed [optional]
 
-Use this section if you need things from the project. Examples include a new
-subproject, repos requested, github details, and/or testing infrastructure.
-
-Listing these here allows the community to get the process for these resources
-started right away.

--- a/enhancements/tackle/pathfinder-tca-integration.md
+++ b/enhancements/tackle/pathfinder-tca-integration.md
@@ -36,9 +36,9 @@ None
 
 This enhancement proposes to have Tackle Application Inventory and Tackle Pathfinder integrate with Tackle Container Advisor for two purposes:
 
-1. The technology standardization of TCA can be used to take application descriptions and create consistent tags in the Application Inventory
+1. The standardization technology of Tackle Container Advisor can be used to take application descriptions and create consistent tags in the Application Inventory based on the technology used by the application.
 
-2. The output from TCA can be additional input to the report that Pathfinder generates to determine the disposition of a workload in the cloud by identifying if it is suitable for containerization and if so what container images to choose..
+2. The containerization recommendations from Tackle Container Advisor can be additional input to the report that Pathfinder generates to determine the disposition of a workload in the cloud by identifying if it is suitable for containerization and if so what container images to choose.
 
 ## Motivation
 
@@ -83,7 +83,7 @@ The Migration Architect is responsible for determining teh disposition of each a
 
 #### Tackle Pathfinder Implementation
 
-The proposed solution for Tackle Pathfinder integration is for TCA to create a Command Line Interface (CLI) that could be invoked as an Add-On to Pathfinder following it's add-on architecture. TCA is currently a Python microservice that runs as a service.
+The proposed solution for Tackle Pathfinder integration is for TCA to create a Command Line Interface (CLI) that could be invoked as an Add-On to Pathfinder following its add-on architecture. TCA is currently a Python microservice that runs as a service.
 
 #### Tackle Application Inventory Implementation
 


### PR DESCRIPTION
This proposal is to integrate Tackle Container Advisor (TCA) with both the Tackle Application Inventory for the purpose of automatically and consistently tagging applications with their technologies, and with Tackle Pathfinder for including containerization advice in the Pathfinder report for the purpose of aiding in determining the 6R disposition of an application.