### PR TITLE
:book: Refactor generic provider into specific providers

### DIFF
--- a/enhancements/generic-to-specific-providers/generic-provider-to-specific-providers.md
+++ b/enhancements/generic-to-specific-providers/generic-provider-to-specific-providers.md
@@ -8,7 +8,7 @@ reviewers:
 approvers:
   - TBD
 creation-date: 2026-03-13
-last-updated: 2026-03-13
+last-updated: 2026-03-28
 status: provisional
 see-also:
   - "https://github.com/konveyor/analyzer-lsp/issues/1013"
@@ -17,7 +17,7 @@ see-also:
 
 # Refactor Generic Service Client to Language-Specific Providers
 
-This enhancement proposes splitting the current "generic external provider" in analyzer-lsp into separate, language-specific providers (e.g. Go, Python, Node.js), each with its own binary and initialization path. The goal is to align with the reality that LSP server initialization and behavior differ too much across languages to be reliably abstracted behind a single generic client.
+This enhancement proposes splitting the current "generic external provider" in analyzer-lsp into separate, language-specific providers (Go, Python, Node.js), each with its own binary and initialization path. The goal is to align with the reality that LSP server initialization and behavior differ too much across languages to be reliably abstracted behind a single generic client. Maintainer review ([konveyor/enhancements#262](https://github.com/konveyor/enhancements/pull/262)) settled the following: **fully remove** the generic multi-language binary and dispatcher; ship **one container image per language** (smaller images, simpler debugging, fewer unrelated providers in a given deployment); treat YAML analysis as the responsibility of the existing **yq** provider and **deprecate/remove** the generic provider’s `yaml_language_server` path rather than spinning up a parallel YAML LSP provider; accept a **breaking change** for direct consumers of provider binaries (hub/kai/kantra and related tooling are the main integrators—users who need the old layout can pin an older image); and name the Go backend explicitly (e.g. **golang** / `go-external-provider`) so nothing called “generic” implies support for arbitrary language servers.
 
 The YAML `title` is lowercased with spaces replaced by `-`.
 
@@ -28,34 +28,28 @@ The YAML `title` is lowercased with spaces replaced by `-`.
 - [ ] Test plan is defined
 - [ ] User-facing documentation is created
 
-## Open Questions
-
-1. **YAML strategy:** Default container settings use `yq-external-provider` for YAML, not the generic provider's `yaml_language_server` config. Should we (a) introduce a dedicated yaml-external-provider that uses the current yaml_language_server code, or (b) leave YAML to yq only and deprecate/remove the yaml_language_server backend from the generic provider?
-
-2. **Image topology:** Should we ship one container image per language (e.g. go-provider, python-provider, nodejs-provider) or a single image that includes multiple provider binaries and an entrypoint that selects by argument/env? The former simplifies per-language ownership and sizing; the latter may reduce CI and deployment surface.
-
-3. **Backward compatibility:** Should we retain a "generic" binary that supports only the current "generic" (gopls) client so that existing configs using `binaryPath: ".../generic-external-provider"` with `lspServerName: "generic"` continue to work without change, or is a breaking change to provider config acceptable?
-
 ## Summary
 
-Today, analyzer-lsp uses a single binary, `generic-external-provider`, to serve multiple LSP-backed languages (Go/gopls, Python/pylsp, Node.js, and optionally YAML). The same binary is started multiple times with different `--name` flags; internally, a generic provider type dispatches to language-specific "service client builders" via a map and a runtime switch on `lspServerName`. Experience has shown that a single generic client cannot reliably interface with every language server because initialization and behavior differ too much (e.g. custom LSP handlers for YAML, custom reference-evaluation for Node.js, different capability sets). This enhancement proposes replacing that design with one provider per language—each with its own binary and no runtime dispatcher—following the pattern already used by `java-external-provider`. Shared logic (e.g. `lsp/base_service_client`) would remain; only the multi-language dispatcher and the convention of "one binary, many names" would go away. Users and operators would configure separate provider entries (and binaries/images) per language, improving clarity, maintainability, and reliability of each language backend.
+Today, analyzer-lsp uses a single binary, `generic-external-provider`, to serve multiple LSP-backed languages (Go/gopls, Python/pylsp, Node.js, and a YAML LSP path that does not match how YAML is usually configured in defaults, which already favor `yq-external-provider`). The same binary is started multiple times with different `--name` flags; internally, a generic provider type dispatches to language-specific "service client builders" via a map and a runtime switch on `lspServerName`. Experience has shown that a single generic client cannot reliably interface with every language server because initialization and behavior differ too much (e.g. custom LSP handlers for YAML, custom reference-evaluation for Node.js, different capability sets). The name “generic” is misleading: the implementation cannot treat arbitrary language servers interchangeably; a genuinely generic LSP client, if ever needed, would be a **different** design. This enhancement proposes **removing** that binary and dispatcher entirely and replacing them with one provider per language—each with its own binary and **dedicated container image**—following the pattern already used by `java-external-provider`. YAML stays on the **yq** provider; the generic provider’s `yaml_language_server` support is deprecated/removed as part of the split. Language providers keep using the shared **`lsp/base_service_client`** stack, but that library is also a **rewrite/refactor target**: structure and clarity should improve so the shared LSP layer is easier to follow and change than today. Only the multi-language dispatcher and the convention of "one binary, many names" go away. Integrators (e.g. hub, kai, kantra) update configs to point at the new per-language binaries and images; this is an acceptable **breaking change** for those references.
 
 ## Motivation
 
 ### Goals
 
 - **Reliability:** Each language provider owns its LSP initialization and capabilities so that language-specific quirks (e.g. YAML `workspace/configuration` handling, Node.js batching) are implemented in one place without conditional logic in a shared dispatcher.
-- **Clarity:** One binary per language (or one clear entrypoint per language) so that configuration, debugging, and ownership are straightforward.
+- **Clarity:** One binary and one container image per language so that configuration, debugging, and ownership are straightforward.
 - **Consistency:** Align Go, Python, and Node.js providers with the existing pattern used by the Java provider (dedicated binary and package).
 - **Maintainability:** Remove the generic provider's runtime switch on `lspServerName` and the `SupportedLanguages` map so that adding or changing a language does not touch a central dispatcher.
+- **Shared LSP library:** Refactor or rewrite `lsp/base_service_client` so the code is easier to understand, navigate, and extend (clearer module boundaries, naming, and flow), without changing the outward provider gRPC contract or the `BaseClient` / `ServiceClient` interfaces that the analyzer uses.
+- **E2E ownership:** End-to-end (demo) tests for each language provider live **with that provider**—the same model as `java-external-provider/e2e-tests/` and `yq-external-provider/e2e-tests/`—not bundled only under `generic-external-provider`. CI should invoke those paths per provider (e.g. `.github/workflows/demo-testing.yml` matrix entries), including if a provider later moves to its **own Git repository**.
 
-Success will be evident when: (1) Go, Python, and Node.js (and optionally YAML) are each served by a dedicated provider binary/package; (2) no single process dispatches to multiple LSP types via `lspServerName`; (3) provider settings and docs reference distinct binaries/images per language; (4) existing tests and demos pass with the new layout.
+Success will be evident when: (1) Go, Python, and Node.js are each served by a dedicated provider binary/package and image; (2) YAML analysis continues to be configured via the **yq** provider, with generic-provider YAML LSP code removed or unused; (3) no single process dispatches to multiple LSP types via `lspServerName`; (4) provider settings and docs reference distinct binaries/images per language; (5) `lsp/base_service_client` has been materially revised and reviewers can agree it is simpler to work in than the pre-refactor layout; (6) Go, Python, and Node.js **e2e test assets** (demo output, provider settings, rules) and workflows reference only their respective provider trees—nothing language-specific remains under `generic-external-provider/e2e-tests/`; (7) existing tests and demos pass with the new layout.
 
 ### Non-Goals
 
 - Changing the analyzer-lsp provider gRPC API or the `BaseClient`/`ServiceClient` interfaces.
-- Removing or rewriting the shared `lsp/base_service_client` layer; it remains the foundation for LSP-based providers.
-- Changing how the builtin provider or non-generic providers (e.g. Java, yq) are implemented or configured.
+- Dropping the shared LSP layer entirely: `lsp/base_service_client` (or its successor in the same role) remains the foundation for LSP-based external providers; the goal is to **improve** it, not replace it with unrelated ad-hoc code per language.
+- Changing how the built-in provider or non-generic providers (e.g. Java, yq) are implemented or configured.
 - Supporting multiple LSP types in a single process as a feature; the refactor explicitly moves away from that model.
 
 ## Proposal
@@ -64,7 +58,7 @@ Success will be evident when: (1) Go, Python, and Node.js (and optionally YAML) 
 
 #### Story 1: Operator configures Go analysis
 
-As an operator, I want to configure the analyzer to use a Go provider by pointing to a dedicated Go provider binary (e.g. `go-external-provider` or a renamed generic binary that only supports gopls), so that I do not rely on `lspServerName` in providerSpecificConfig and the behavior of the Go provider is isolated from other languages.
+As an operator, I want to configure the analyzer to use a Go provider by pointing to a dedicated Go binary (e.g. `go-external-provider` / golang provider), so that I do not rely on `lspServerName` in providerSpecificConfig and the Go backend is not confused with a multi-language “generic” server.
 
 #### Story 2: Operator configures Python and Node.js analysis
 
@@ -74,65 +68,83 @@ As an operator, I want to configure Python and Node.js providers using distinct 
 
 As a developer, I want to add or modify support for a single language (e.g. Python) without editing a central "generic" provider or a shared `SupportedLanguages` map, so that changes are localized to that language’s provider package and binary.
 
+#### Story 4: Developer runs e2e for one language
+
+As a developer, I want Go, Python, and Node.js e2e/demo tests to live under **that provider’s** directory (or repo), consistent with Java and yq, so that I can change one language’s provider or image and run its e2e without pulling in unrelated languages.
+
+#### Story 5: Developer works on shared LSP client code
+
+As a developer, I want `lsp/base_service_client` to be organized and documented so that behavior, extension points, and call flow are obvious, so that fixes and features do not require reverse-engineering a large, opaque type hierarchy.
+
 ### Implementation Details/Notes/Constraints
 
 - **Current architecture (brief):** The analyzer loads provider configs (e.g. `provider_container_settings.json`); for each config with a `binaryPath`, the gRPC client layer runs that binary with `--port` and `--name` (where `--name` is taken from `initConfig[0].providerSpecificConfig.lspServerName`, default `"generic"`). The generic-external-provider binary constructs a `genericProvider` keyed by `--name`, which looks up a builder in `SupportedLanguages` and later may switch builders in `Init()` if config sends a different `lspServerName`. Each builder builds LSP `InitializeParams` and handlers in language-specific ways and returns a `ServiceClient` that embeds `LSPServiceClientBase` and an evaluator.
 
-- **Target architecture:** Each of Go, Python, and Node.js (and optionally YAML) gets its own provider package and binary. Each binary implements `BaseClient` (e.g. `Capabilities()`, `Init()`) and constructs exactly one service client type (no map, no switch on `lspServerName`). The analyzer continues to spawn one process per provider config; configs will reference different `binaryPath` values per language. Shared code in `lsp/base_service_client` (and shared capability helpers where applicable) is reused by each provider.
+- **Target architecture:** Each of Go, Python, and Node.js gets its own provider package, binary, and **container image**. Each binary implements `BaseClient` (e.g. `Capabilities()`, `Init()`) and constructs exactly one service client type (no map, no switch on `lspServerName`). The analyzer continues to spawn one process per provider config; configs will reference different `binaryPath` values per language. **`lsp/base_service_client`:** refactored or rewritten so shared LSP client behavior lives in a clearer structure; each language provider imports and specializes that layer (and shared capability helpers where applicable) instead of duplicating it. **YAML:** no new LSP-based YAML provider is introduced from the generic split; operators use **yq-external-provider** (existing), and `yaml_language_server` code under the generic provider is deprecated/removed.
 
 - **Reference implementation:** `java-external-provider` is the pattern: own main, own package, no dependency on the generic provider or `SupportedLanguages`.
 
 - **Key files to change or introduce:**
-  - **Analyzer core:** `provider/grpc/provider.go` — `start()` today passes `--name` derived from `lspServerName`; for language-specific binaries this can be simplified or kept for backward compat. No change to `BaseClient`/`ServiceClient` interfaces.
-  - **Generic provider (remove or shrink):** `external-providers/generic-external-provider/main.go`, `pkg/generic_external_provider/provider.go`, `pkg/server_configurations/constants.go`; move `server_configurations/generic`, `pylsp`, `nodejs`, (and optionally `yaml_language_server`) into new provider modules.
+  - **Analyzer core:** `provider/grpc/provider.go` — `start()` today passes `--name` derived from `lspServerName`; for language-specific binaries this can be simplified once configs no longer depend on the generic multi-language binary. No change to `BaseClient`/`ServiceClient` interfaces.
+  - **Shared LSP layer:** `lsp/base_service_client` (and closely related packages under `lsp/`) — refactor for clarity and maintainability; preserve external contracts used by the analyzer and by provider binaries.
+  - **Generic provider (remove):** `external-providers/generic-external-provider/main.go`, `pkg/generic_external_provider/provider.go`, `pkg/server_configurations/constants.go`; move `server_configurations/generic`, `pylsp`, and `nodejs` into new provider modules; drop or retire `yaml_language_server` in favor of yq.
   - **New providers:** New directories, e.g. `go-external-provider`, `python-external-provider`, `nodejs-external-provider`, each with its own `main.go`, provider type, and one server configuration (no dispatcher).
-  - **Config and build:** Update `provider_container_settings.json`, Makefile, root Dockerfile, generic-provider Dockerfile (or replace with per-language Dockerfiles), `.github/workflows/image-build.yaml`, `.github/workflows/demo-testing.yml`, and testdata/docs as needed.
+  - **Config and build:** Update `provider_container_settings.json`, Makefile, root Dockerfile, replace generic-provider image build with **per-language** Dockerfiles/images, `.github/workflows/image-build.yaml`, `.github/workflows/demo-testing.yml`, and testdata/docs as needed. **E2E / demos:** Today, golang-, python-, and nodejs-e2e assets live under `external-providers/generic-external-provider/e2e-tests/` while Java and yq already use `external-providers/<provider>/e2e-tests/`. **Move** each language’s e2e tree beside its new provider (e.g. `go-external-provider/e2e-tests/`, mirroring `java-external-provider/e2e-tests/`). Update `.github/workflows/demo-testing.yml` (and any related konveyor CI) so each matrix entry points at the **owning** provider path; align with `external-providers/TESTING.md`. If a provider is published from a **separate Git repository** in the future, its e2e should travel with that repo.
   - **Tests:** Move or duplicate `server_configurations/*/service_client_test.go` into the new provider packages; adjust `provider/provider_test.go` if it asserts on generic-provider-specific behavior.
 
 - **Constraint:** The analyzer calls `Capabilities()` before `Init()`, so each process must advertise the correct capabilities at startup. With one binary per language, this is natural; no runtime switch is required.
 
+- **Follow-up (post–per-language split):** Compare LSP-backed provider architecture: **continue building on a refactored `lsp/base_service_client`** vs **leaning on `provider.NewServer` and `ServiceClient` with a thinner LSP layer** (more explicit per-language LSP code, less reliance on a monolithic shared base). Document tradeoffs—duplication vs clarity, blast radius of protocol or analyzer changes, and the fact that TLS/JWT for the **gRPC** side already live in the `provider` server implementation—and record a maintainer decision or short ADR.
+
 ### Security, Risks, and Mitigations
 
-- **Risk: More binaries/images.** More artifacts to build, sign, and distribute. Mitigation: Document the new layout clearly; consider a single image with multiple binaries and an entrypoint if the community prefers to limit the number of images.
-- **Risk: Breaking existing configs.** Users who currently use one `binaryPath` and multiple `initConfig`/`lspServerName` entries will need to point each language to its own binary. Mitigation: Provide a migration path (e.g. retain a "generic" binary for gopls-only) and update default settings and docs.
-- **Risk: Regressions in behavior.** Each language’s logic is moved into a new package. Mitigation: Preserve existing tests (move or re-run), run existing e2e/demos (golang-e2e, python-e2e, nodejs-e2e) against the new providers, and add any missing integration tests.
+- **Risk: More binaries/images.** More artifacts to build, sign, and distribute. Mitigation: Document the new layout clearly; **separate images per language** are the chosen model (smaller deploys, easier debugging, fewer unrelated providers in one image). A single image bundling multiple binaries remains a theoretical alternative but is not the default plan.
+- **Risk: Regressions in behavior.** Each language’s logic is moved into a new package, and the shared LSP layer changes shape. Mitigation: Preserve existing tests (move or re-run), extend unit coverage for `lsp/base_service_client` where gaps appear after the rewrite, run **per-provider** e2e/demos after assets are relocated (same scenarios as today’s golang/python/nodejs flows, new paths), and add any missing integration tests.
 - **Security:** No new network exposure or auth model; providers remain out-of-process gRPC services. Binary execution is unchanged (analyzer still spawns one process per provider config). Review by maintainers familiar with the provider and analyzer-lsp security model is sufficient.
 
 ## Design Details
 
 ### Test Plan
 
-- **Unit tests:** Each new provider package must have unit tests for its provider type (Capabilities, Init) and for its service client behavior where non-trivial (e.g. Node.js or YAML-specific evaluation). Existing tests under `external-providers/generic-external-provider/pkg/server_configurations/*/service_client_test.go` will be moved or reimplemented in the new packages so that behavior is preserved.
-- **Integration / e2e:** Existing demo and e2e flows (e.g. golang-e2e, python-e2e, nodejs-e2e in `external-providers/generic-external-provider/e2e-tests/` and `.github/workflows/demo-testing.yml`) will be updated to use the new provider binaries/images and re-run to ensure no regressions.
+- **Unit tests:** Each new provider package must have unit tests for its provider type (Capabilities, Init) and for its service client behavior where non-trivial (e.g. Node.js-specific evaluation). The refactor of `lsp/base_service_client` should keep or improve test coverage for shared behavior (handlers, initialization helpers, and any code moved out of provider-specific packages). Existing tests under `external-providers/generic-external-provider/pkg/server_configurations/*/service_client_test.go` will be moved or reimplemented in the new packages so that behavior is preserved.
+- **Integration / e2e:** **Per-provider layout (maintainer expectation):** e2e/demo assets must live with each language provider—the pattern already used for `java-external-provider` and `yq-external-provider`—not under a shared generic-provider tree. **Migrate** today’s `generic-external-provider/e2e-tests/{golang,python,nodejs}-e2e/` content into `go-external-provider`, `python-external-provider`, and `nodejs-external-provider` (or final directory names), each with its own `e2e-tests/` (see `external-providers/TESTING.md`). Update `.github/workflows/demo-testing.yml` so jobs reference those paths and the new images. This matches the direction that e2e is **split across providers** (and can follow a provider into its **own repository** if the project splits repos later).
 - **Isolation:** Each language provider can be tested in isolation by running its binary with the same gRPC contract; the analyzer’s existing provider client logic does not need to change beyond how it starts the binary (and possibly how `--name` is passed).
-- Tricky areas: (1) Ensuring capability lists and Init parameters match what the analyzer expects for each provider name. (2) YAML if we introduce a dedicated provider—tests for the yaml_language_server path should be retained or moved.
+- Tricky areas: (1) Ensuring capability lists and Init parameters match what the analyzer expects for each provider name. (2) YAML: validate **yq** flows; remove or replace coverage that only applied to `yaml_language_server` under the generic provider.
+
+### Follow-up design work
+
+- **Provider gRPC vs LSP layering:** After each language has its own external provider binary, run the comparison described under **Implementation Details** (*Follow-up (post–per-language split)*): refactored `lsp/base_service_client` vs a design that emphasizes `provider.NewServer` / `ServiceClient` and a slimmer LSP stack. Capture the outcome in the enhancement or a linked ADR so future providers follow one clear pattern.
 
 ### Upgrade / Downgrade Strategy
 
-- **Upgrade:** Users currently using the generic-external-provider for go, python, or nodejs must update their provider settings to use the new per-language binaries (and, if applicable, new image names). If we retain a "generic" binary that only supports gopls, configs that use only `lspServerName: "generic"` can keep the same binaryPath until that binary is eventually deprecated. Documentation and default `provider_container_settings.json` (or equivalent) will be updated to reflect the new layout.
-- **Downgrade:** Reverting to the previous release would require restoring the single generic-external-provider binary and configs that use `lspServerName` to select the language. No schema change to the analyzer’s provider config format is required; only the number and identity of binaries and the presence of `lspServerName` in config may change.
+- **Upgrade:** Consumers currently using `generic-external-provider` for Go, Python, or Node.js must update provider settings to the new per-language binaries and images (including operator/extension references where applicable). Documentation and default `provider_container_settings.json` (or equivalent) will reflect the new layout. There is **no** commitment to keep a long-lived shim named `generic-external-provider` for gopls-only use; the Go path should be explicitly named (e.g. golang / go provider).
+- **Downgrade:** Reverting to a previous release means restoring the old generic binary and configs that used `lspServerName` to select the language. No schema change to the analyzer’s provider config format is required; only the number and identity of binaries and images change.
 
 ## Implementation History
 
 | Date       | Status / Milestone |
 |-----------|---------------------|
-| 2025-03-11 | Enhancement proposed (provisional); refactoring analysis document added. |
+| 2026-03-13 | Enhancement proposed (provisional); refactoring analysis document added. |
+| 2026-03-25 | Updated enhancement proposal with feedback from reviewers. |
 
 ## Drawbacks
 
 - **Operational overhead:** Operators must manage and optionally image-scan more than one provider binary/image if we ship separate images per language.
 - **Duplication of structure:** Each language provider will have its own main and provider type, which repeats some boilerplate (flag parsing, server startup). This is intentional for isolation but increases code surface.
-- **Breaking change for current generic users:** Anyone relying on a single generic binary with multiple `lspServerName` values will need to switch to multiple provider entries and binaries (unless we keep a generic binary for gopls-only and document it as the “Go” provider).
+- **Scope of the shared-layer rewrite:** A large refactor of `lsp/base_service_client` can slip in scope or schedule if not bounded; tie milestones to the per-provider split and keep the `BaseClient`/`ServiceClient` boundary stable.
+- **Breaking change for current generic users:** Anyone relying on a single generic binary with multiple `lspServerName` values must switch to multiple provider entries, binaries, and images; pinning an older release is the compatibility story for stragglers.
 
 ## Alternatives
 
 1. **Keep the generic provider and only fix initialization per language.** We could leave the single binary and dispatcher in place and try to make initialization more pluggable (e.g. more builder options). This was considered insufficient because the issue states that a generic client cannot reliably interface with every language server; the problem is structural, not just a few missing options.
 
-2. **Single image with multiple binaries and a router entrypoint.** We could keep one container image that contains go-external-provider, python-external-provider, nodejs-external-provider and an entrypoint that invokes the right binary based on env or args. This preserves “one image” for deployment while still allowing separate codebases and no in-process dispatcher. This is left as an option in Open Questions (image topology).
+2. **Single image with multiple binaries and a router entrypoint.** We could keep one container image that contains go-external-provider, python-external-provider, nodejs-external-provider and an entrypoint that invokes the right binary based on env or args. This preserves “one image” for deployment while still allowing separate codebases and no in-process dispatcher. **Rejected** as the primary approach in favor of **one image per language** (maintainer preference: image size, isolation, debuggability).
 
-3. **Leave YAML in the generic provider only.** If we do not introduce a dedicated yaml-external-provider, we could leave the yaml_language_server code in a shrunken “generic” provider that only supports generic (gopls) and yaml. That would reduce the number of new provider modules at the cost of retaining a small dispatcher for two backends.
+3. **Leave YAML in the generic provider only.** A shrunken generic supporting only gopls and `yaml_language_server` would retain a small dispatcher. **Rejected** in favor of **yq** for YAML and full removal of the generic provider.
 
 ## Infrastructure Needed
 
-- CI jobs (or matrix entries) to build and test each new provider binary and, if applicable, per-language images. The exact layout (one job per provider vs one job building multiple binaries) can follow the decision on image topology.
-- No new repositories or subprojects are required; new providers can live under `external-providers/` in the analyzer-lsp repo, consistent with `java-external-provider` and `yq-external-provider`.
+- CI jobs (or matrix entries) to build and test each new provider binary and **each per-language image**.
+- **Demo / e2e CI:** Workflow matrix (e.g. `demo-testing.yml`) must treat each provider as a **separate** e2e target with paths under `external-providers/<provider>/e2e-tests/`, not a single generic-provider folder for multiple languages.
+- **Konveyor operator:** The operator’s **Python** and **Node.js** extensions (and any CRs or defaults that pin provider images) must be updated to reference the **new per-language container images** once those images ship—see [konveyor/enhancements#262](https://github.com/konveyor/enhancements/pull/262) (comment by @jortel). Coordinate release timing between analyzer-lsp image publishes and operator releases.
+- No new repositories or subprojects are required for the initial split; new providers can live under `external-providers/` in the analyzer-lsp repo, consistent with `java-external-provider` and `yq-external-provider`. E2e layout should still assume providers **could** move to their own repos later without re-bundling tests.

--- a/enhancements/generic-to-specific-providers/generic-provider-to-specific-providers.md
+++ b/enhancements/generic-to-specific-providers/generic-provider-to-specific-providers.md
@@ -1,0 +1,139 @@
+---
+title: generic-provider-to-specific-providers
+authors:
+  - "@jmle"
+  - "@pranavgaikwad"
+  - "@savitharaghunathan"
+reviewers:
+  - TBD
+approvers:
+  - TBD
+creation-date: 2025-03-11
+last-updated: 2025-03-11
+status: provisional
+see-also:
+  - "https://github.com/konveyor/analyzer-lsp/issues/1013"
+  - "docs/refactoring-generic-provider-to-specific-providers.md"
+---
+
+# Refactor Generic Service Client to Language-Specific Providers
+
+This enhancement proposes splitting the current "generic external provider" in analyzer-lsp into separate, language-specific providers (e.g. Go, Python, Node.js), each with its own binary and initialization path. The goal is to align with the reality that LSP server initialization and behavior differ too much across languages to be reliably abstracted behind a single generic client.
+
+The YAML `title` is lowercased with spaces replaced by `-`.
+
+## Release Signoff Checklist
+
+- [ ] Enhancement is `implementable`
+- [ ] Design details are appropriately documented from clear requirements
+- [ ] Test plan is defined
+- [ ] User-facing documentation is created
+
+## Open Questions
+
+1. **YAML strategy:** Default container settings use `yq-external-provider` for YAML, not the generic provider's `yaml_language_server` config. Should we (a) introduce a dedicated yaml-external-provider that uses the current yaml_language_server code, or (b) leave YAML to yq only and deprecate/remove the yaml_language_server backend from the generic provider?
+
+2. **Image topology:** Should we ship one container image per language (e.g. go-provider, python-provider, nodejs-provider) or a single image that includes multiple provider binaries and an entrypoint that selects by argument/env? The former simplifies per-language ownership and sizing; the latter may reduce CI and deployment surface.
+
+3. **Backward compatibility:** Should we retain a "generic" binary that supports only the current "generic" (gopls) client so that existing configs using `binaryPath: ".../generic-external-provider"` with `lspServerName: "generic"` continue to work without change, or is a breaking change to provider config acceptable?
+
+## Summary
+
+Today, analyzer-lsp uses a single binary, `generic-external-provider`, to serve multiple LSP-backed languages (Go/gopls, Python/pylsp, Node.js, and optionally YAML). The same binary is started multiple times with different `--name` flags; internally, a generic provider type dispatches to language-specific "service client builders" via a map and a runtime switch on `lspServerName`. Experience has shown that a single generic client cannot reliably interface with every language server because initialization and behavior differ too much (e.g. custom LSP handlers for YAML, custom reference-evaluation for Node.js, different capability sets). This enhancement proposes replacing that design with one provider per language—each with its own binary and no runtime dispatcher—following the pattern already used by `java-external-provider`. Shared logic (e.g. `lsp/base_service_client`) would remain; only the multi-language dispatcher and the convention of "one binary, many names" would go away. Users and operators would configure separate provider entries (and binaries/images) per language, improving clarity, maintainability, and reliability of each language backend.
+
+## Motivation
+
+### Goals
+
+- **Reliability:** Each language provider owns its LSP initialization and capabilities so that language-specific quirks (e.g. YAML `workspace/configuration` handling, Node.js batching) are implemented in one place without conditional logic in a shared dispatcher.
+- **Clarity:** One binary per language (or one clear entrypoint per language) so that configuration, debugging, and ownership are straightforward.
+- **Consistency:** Align Go, Python, and Node.js providers with the existing pattern used by the Java provider (dedicated binary and package).
+- **Maintainability:** Remove the generic provider's runtime switch on `lspServerName` and the `SupportedLanguages` map so that adding or changing a language does not touch a central dispatcher.
+
+Success will be evident when: (1) Go, Python, and Node.js (and optionally YAML) are each served by a dedicated provider binary/package; (2) no single process dispatches to multiple LSP types via `lspServerName`; (3) provider settings and docs reference distinct binaries/images per language; (4) existing tests and demos pass with the new layout.
+
+### Non-Goals
+
+- Changing the analyzer-lsp provider gRPC API or the `BaseClient`/`ServiceClient` interfaces.
+- Removing or rewriting the shared `lsp/base_service_client` layer; it remains the foundation for LSP-based providers.
+- Changing how the builtin provider or non-generic providers (e.g. Java, yq) are implemented or configured.
+- Supporting multiple LSP types in a single process as a feature; the refactor explicitly moves away from that model.
+
+## Proposal
+
+### User Stories
+
+#### Story 1: Operator configures Go analysis
+
+As an operator, I want to configure the analyzer to use a Go provider by pointing to a dedicated Go provider binary (e.g. `go-external-provider` or a renamed generic binary that only supports gopls), so that I do not rely on `lspServerName` in providerSpecificConfig and the behavior of the Go provider is isolated from other languages.
+
+#### Story 2: Operator configures Python and Node.js analysis
+
+As an operator, I want to configure Python and Node.js providers using distinct binaries (e.g. `python-external-provider`, `nodejs-external-provider`) and provider entries in my settings file, so that each language has its own process and I can scale or debug them independently.
+
+#### Story 3: Developer adds or changes a language provider
+
+As a developer, I want to add or modify support for a single language (e.g. Python) without editing a central "generic" provider or a shared `SupportedLanguages` map, so that changes are localized to that language’s provider package and binary.
+
+### Implementation Details/Notes/Constraints
+
+- **Current architecture (brief):** The analyzer loads provider configs (e.g. `provider_container_settings.json`); for each config with a `binaryPath`, the gRPC client layer runs that binary with `--port` and `--name` (where `--name` is taken from `initConfig[0].providerSpecificConfig.lspServerName`, default `"generic"`). The generic-external-provider binary constructs a `genericProvider` keyed by `--name`, which looks up a builder in `SupportedLanguages` and later may switch builders in `Init()` if config sends a different `lspServerName`. Each builder builds LSP `InitializeParams` and handlers in language-specific ways and returns a `ServiceClient` that embeds `LSPServiceClientBase` and an evaluator.
+
+- **Target architecture:** Each of Go, Python, and Node.js (and optionally YAML) gets its own provider package and binary. Each binary implements `BaseClient` (e.g. `Capabilities()`, `Init()`) and constructs exactly one service client type (no map, no switch on `lspServerName`). The analyzer continues to spawn one process per provider config; configs will reference different `binaryPath` values per language. Shared code in `lsp/base_service_client` (and shared capability helpers where applicable) is reused by each provider.
+
+- **Reference implementation:** `java-external-provider` is the pattern: own main, own package, no dependency on the generic provider or `SupportedLanguages`.
+
+- **Key files to change or introduce:**
+  - **Analyzer core:** `provider/grpc/provider.go` — `start()` today passes `--name` derived from `lspServerName`; for language-specific binaries this can be simplified or kept for backward compat. No change to `BaseClient`/`ServiceClient` interfaces.
+  - **Generic provider (remove or shrink):** `external-providers/generic-external-provider/main.go`, `pkg/generic_external_provider/provider.go`, `pkg/server_configurations/constants.go`; move `server_configurations/generic`, `pylsp`, `nodejs`, (and optionally `yaml_language_server`) into new provider modules.
+  - **New providers:** New directories, e.g. `go-external-provider`, `python-external-provider`, `nodejs-external-provider`, each with its own `main.go`, provider type, and one server configuration (no dispatcher).
+  - **Config and build:** Update `provider_container_settings.json`, Makefile, root Dockerfile, generic-provider Dockerfile (or replace with per-language Dockerfiles), `.github/workflows/image-build.yaml`, `.github/workflows/demo-testing.yml`, and testdata/docs as needed.
+  - **Tests:** Move or duplicate `server_configurations/*/service_client_test.go` into the new provider packages; adjust `provider/provider_test.go` if it asserts on generic-provider-specific behavior.
+
+- **Constraint:** The analyzer calls `Capabilities()` before `Init()`, so each process must advertise the correct capabilities at startup. With one binary per language, this is natural; no runtime switch is required.
+
+### Security, Risks, and Mitigations
+
+- **Risk: More binaries/images.** More artifacts to build, sign, and distribute. Mitigation: Document the new layout clearly; consider a single image with multiple binaries and an entrypoint if the community prefers to limit the number of images.
+- **Risk: Breaking existing configs.** Users who currently use one `binaryPath` and multiple `initConfig`/`lspServerName` entries will need to point each language to its own binary. Mitigation: Provide a migration path (e.g. retain a "generic" binary for gopls-only) and update default settings and docs.
+- **Risk: Regressions in behavior.** Each language’s logic is moved into a new package. Mitigation: Preserve existing tests (move or re-run), run existing e2e/demos (golang-e2e, python-e2e, nodejs-e2e) against the new providers, and add any missing integration tests.
+- **Security:** No new network exposure or auth model; providers remain out-of-process gRPC services. Binary execution is unchanged (analyzer still spawns one process per provider config). Review by maintainers familiar with the provider and analyzer-lsp security model is sufficient.
+
+## Design Details
+
+### Test Plan
+
+- **Unit tests:** Each new provider package must have unit tests for its provider type (Capabilities, Init) and for its service client behavior where non-trivial (e.g. Node.js or YAML-specific evaluation). Existing tests under `external-providers/generic-external-provider/pkg/server_configurations/*/service_client_test.go` will be moved or reimplemented in the new packages so that behavior is preserved.
+- **Integration / e2e:** Existing demo and e2e flows (e.g. golang-e2e, python-e2e, nodejs-e2e in `external-providers/generic-external-provider/e2e-tests/` and `.github/workflows/demo-testing.yml`) will be updated to use the new provider binaries/images and re-run to ensure no regressions.
+- **Isolation:** Each language provider can be tested in isolation by running its binary with the same gRPC contract; the analyzer’s existing provider client logic does not need to change beyond how it starts the binary (and possibly how `--name` is passed).
+- Tricky areas: (1) Ensuring capability lists and Init parameters match what the analyzer expects for each provider name. (2) YAML if we introduce a dedicated provider—tests for the yaml_language_server path should be retained or moved.
+
+### Upgrade / Downgrade Strategy
+
+- **Upgrade:** Users currently using the generic-external-provider for go, python, or nodejs must update their provider settings to use the new per-language binaries (and, if applicable, new image names). If we retain a "generic" binary that only supports gopls, configs that use only `lspServerName: "generic"` can keep the same binaryPath until that binary is eventually deprecated. Documentation and default `provider_container_settings.json` (or equivalent) will be updated to reflect the new layout.
+- **Downgrade:** Reverting to the previous release would require restoring the single generic-external-provider binary and configs that use `lspServerName` to select the language. No schema change to the analyzer’s provider config format is required; only the number and identity of binaries and the presence of `lspServerName` in config may change.
+
+## Implementation History
+
+| Date       | Status / Milestone |
+|-----------|---------------------|
+| 2025-03-11 | Enhancement proposed (provisional); refactoring analysis document added. |
+
+## Drawbacks
+
+- **Operational overhead:** Operators must manage and optionally image-scan more than one provider binary/image if we ship separate images per language.
+- **Duplication of structure:** Each language provider will have its own main and provider type, which repeats some boilerplate (flag parsing, server startup). This is intentional for isolation but increases code surface.
+- **Breaking change for current generic users:** Anyone relying on a single generic binary with multiple `lspServerName` values will need to switch to multiple provider entries and binaries (unless we keep a generic binary for gopls-only and document it as the “Go” provider).
+
+## Alternatives
+
+1. **Keep the generic provider and only fix initialization per language.** We could leave the single binary and dispatcher in place and try to make initialization more pluggable (e.g. more builder options). This was considered insufficient because the issue states that a generic client cannot reliably interface with every language server; the problem is structural, not just a few missing options.
+
+2. **Single image with multiple binaries and a router entrypoint.** We could keep one container image that contains go-external-provider, python-external-provider, nodejs-external-provider and an entrypoint that invokes the right binary based on env or args. This preserves “one image” for deployment while still allowing separate codebases and no in-process dispatcher. This is left as an option in Open Questions (image topology).
+
+3. **Leave YAML in the generic provider only.** If we do not introduce a dedicated yaml-external-provider, we could leave the yaml_language_server code in a shrunken “generic” provider that only supports generic (gopls) and yaml. That would reduce the number of new provider modules at the cost of retaining a small dispatcher for two backends.
+
+## Infrastructure Needed
+
+- CI jobs (or matrix entries) to build and test each new provider binary and, if applicable, per-language images. The exact layout (one job per provider vs one job building multiple binaries) can follow the decision on image topology.
+- No new repositories or subprojects are required; new providers can live under `external-providers/` in the analyzer-lsp repo, consistent with `java-external-provider` and `yq-external-provider`.

--- a/enhancements/generic-to-specific-providers/generic-provider-to-specific-providers.md
+++ b/enhancements/generic-to-specific-providers/generic-provider-to-specific-providers.md
@@ -2,18 +2,17 @@
 title: generic-provider-to-specific-providers
 authors:
   - "@jmle"
-  - "@pranavgaikwad"
-  - "@savitharaghunathan"
 reviewers:
-  - TBD
+  - "@shawn-hurley"
+  - "@eemcmullan"
 approvers:
   - TBD
-creation-date: 2025-03-11
-last-updated: 2025-03-11
+creation-date: 2026-03-13
+last-updated: 2026-03-13
 status: provisional
 see-also:
   - "https://github.com/konveyor/analyzer-lsp/issues/1013"
-  - "docs/refactoring-generic-provider-to-specific-providers.md"
+  - "refactoring-generic-provider-to-specific-providers.md"
 ---
 
 # Refactor Generic Service Client to Language-Specific Providers

--- a/enhancements/generic-to-specific-providers/refactoring-generic-provider-to-specific-providers.md
+++ b/enhancements/generic-to-specific-providers/refactoring-generic-provider-to-specific-providers.md
@@ -1,0 +1,295 @@
+# Refactoring: Generic Service Client to Specific Providers
+
+**Related:** [GitHub Issue #1013](https://github.com/konveyor/analyzer-lsp/issues/1013) — *[refactor]: Generic Service Client to have specific providers.*
+
+This document describes the current architecture of the generic external provider, the rationale for the proposed refactor, and a detailed inventory of every component that would be affected by splitting the generic provider into language-specific providers.
+
+---
+
+## 1. Executive Summary
+
+**Current state:** A single binary, `generic-external-provider`, serves multiple LSP-backed languages (generic/gopls, Python/pylsp, Node.js, YAML). The same binary is started multiple times with different `--name` flags (e.g. `--name generic`, `--name pylsp`, `--name nodejs`). Internally, a single “generic provider” type dispatches to language-specific *service client builders* via a map and a runtime switch on `lspServerName`.
+
+**Proposed change:** Stop using one generic binary as a multi-language dispatcher. Instead, give each language its own provider (and typically its own binary), similar to `java-external-provider`. Each provider would own its LSP initialization and capabilities without sharing a generic dispatcher.
+
+**Reason (from the issue):** *“We are not finding it the case, that we can have a generic client that reliably interfaces with any generic language server. The initialization of those language servers are too different to make this fully compatible.”*
+
+---
+
+## 2. Current Architecture — How the Generic Provider Fits In
+
+### 2.1 Provider discovery and spawning (analyzer-lsp core)
+
+- **Config loading:** `provider.GetConfig(settingsFile)` reads provider configs (e.g. `provider_container_settings.json` or YAML). Each entry has `name`, `binaryPath` or `address`, and `initConfig[]`.
+- **Client creation:** For every config with `name != "builtin"`, `provider/lib.GetProviderClient(config, log)` is used. That function delegates to `grpc.NewGRPCClient(config, log)` for all non-builtin providers.
+- **Binary startup (generic only):** In `provider/grpc/provider.go`, `start()` is called when `config.BinaryPath != ""`. It:
+  1. Reserves a free port.
+  2. Reads `lspServerName` from `config.InitConfig[0].ProviderSpecificConfig["lspServerName"]` (default `"generic"`).
+  3. Runs: `exec.CommandContext(ctx, config.BinaryPath, "--port", port, "--name", name)`.
+  4. Dials `localhost:{port}` and returns the gRPC connection and stdout pipe.
+
+So for a settings file that defines three “providers” (e.g. go, python, nodejs) all using the same `binaryPath: "/usr/local/bin/generic-external-provider"`, the analyzer spawns **three separate processes** of the same binary, each with a different `--name` (e.g. `generic`, `pylsp`, `nodejs`).
+
+**Files:**
+
+| Path | Role |
+|------|------|
+| `provider/provider.go` | `Config`, `InitConfig`, `GetConfig()`, `validateAndUpdateProviderSpecificConfig()`, `BaseClient`, `ServiceClient`, `InternalProviderClient` interfaces. |
+| `provider/lib/lib.go` | `GetProviderClient(config, log)` — branches on `config.Name == "builtin"` → builtin, else → `grpc.NewGRPCClient`. |
+| `provider/grpc/provider.go` | `NewGRPCClient()`, `start()` (spawns binary with `--port` and `--name` from `lspServerName`), `Init()`, `Capabilities()`, `Evaluate()`, etc. |
+| `provider/server.go` | gRPC server used by external provider processes: `NewServer(client BaseClient, ...)`, `Capabilities()`, `Init()`, `Evaluate()`, `Stop()`, etc. |
+| `cmd/analyzer/main.go` | Loads configs, builds `finalConfigs`, calls `lib.GetProviderClient(config, log)` per config, starts providers, runs engine. |
+| `cmd/dep/main.go` | Same pattern for dep command. |
+
+### 2.2 Generic external provider binary and process layout
+
+- **Entrypoint:** `external-providers/generic-external-provider/main.go`
+  - Parses flags: `--port`, `--socket`, `--name` (lsp server name), `--log-level`, TLS, etc.
+  - If `--name` is empty, defaults to `"generic"`.
+  - Builds one provider: `client := generic_external_provider.NewGenericProvider(*lspServerName, log)`.
+  - Starts the gRPC server: `provider.NewServer(client, *port, ...)`.
+
+So each process is “locked” at startup to one LSP type via `--name`; that name is used to choose the initial `ServiceClientBuilder` and the capability set advertised to the analyzer.
+
+**Files:**
+
+| Path | Role |
+|------|------|
+| `external-providers/generic-external-provider/main.go` | Flag parsing, `NewGenericProvider(*lspServerName, log)`, `provider.NewServer(client, ...)`. |
+
+### 2.3 Generic provider type and dispatch
+
+- **Type:** `genericProvider` in `pkg/generic_external_provider/provider.go`
+  - Holds: `lspServerName`, `serviceClientBuilder` (a `serverconf.ServiceClientBuilder`), and a list of `capabilities` derived from that builder.
+- **Construction:** `NewGenericProvider(lspServerName, log)` looks up `serverconf.SupportedLanguages[lspServerName]`; if missing, falls back to `"generic"`. It then stores that builder and builds the capability list from `ctor.GetGenericServiceClientCapabilities(log)`.
+- **Capabilities():** Returns the stored capabilities (so each process advertises only the capabilities for its LSP).
+- **Init():** Receives `provider.InitConfig` from the analyzer (via gRPC). It reads `c.ProviderSpecificConfig["lspServerName"]` again; if it differs from the provider’s current `lspServerName`, it **reassigns** `serviceClientBuilder` via a switch on the known constants (`generic`, `pylsp`, `nodejs`, `yaml_language_server`). Then it calls `p.serviceClientBuilder.Init(ctx, log, c)` and returns the resulting `ServiceClient`.
+
+So:
+- Capabilities are fixed per process (by `--name`).
+- Init can still “switch” the builder at runtime if the config says a different `lspServerName`, which keeps the door open for one process to serve multiple LSP types in theory, but in practice the analyzer spawns one process per provider config and passes matching `lspServerName` in initConfig.
+
+**Files:**
+
+| Path | Role |
+|------|------|
+| `external-providers/generic-external-provider/pkg/generic_external_provider/provider.go` | `genericProvider`, `NewGenericProvider()`, `Capabilities()`, `Init()` (switch on `lspServerName`, delegate to builder). |
+| `external-providers/generic-external-provider/pkg/server_configurations/constants.go` | `GenericClient`, `PythonClient`, `YamlClient`, `NodeClient`; `ServiceClientBuilder` interface; `SupportedLanguages` map. |
+
+### 2.4 Server configurations (per-language “backends”)
+
+Each language has a package under `server_configurations/` that implements:
+
+- A **config struct** (embeds `base.LSPServiceClientConfig`).
+- A **service client struct** (embeds `*base.LSPServiceClientBase` and `*base.LSPServiceClientEvaluator[T]`).
+- A **builder** (e.g. `GenericServiceClientBuilder`) with:
+  - `Init(ctx, log, c provider.InitConfig) (provider.ServiceClient, error)`
+  - `GetGenericServiceClientCapabilities(log) []base.LSPServiceClientCapability`
+
+`Init()` in each builder:
+
+- Unmarshals `c.ProviderSpecificConfig` into the client’s config.
+- Builds LSP `InitializeParams` (RootURI, WorkspaceFolders, Capabilities, InitializationOptions, etc.) in **language-specific ways**.
+- Calls `base.NewLSPServiceClientBase(ctx, log, c, initializeHandler, params)` — the **handler** and **params** differ by language.
+- Builds the evaluator from the capability list and attaches it to the client.
+
+Differences that matter for “initialization is too different”:
+
+| Language | Notable Init / behavior |
+|----------|-------------------------|
+| **generic** | Standard `InitializeParams`; `base.LogHandler(log)`; capabilities: referenced, dependency (no-op), echo. |
+| **pylsp** | Same pattern as generic for Init; capabilities: referenced only. |
+| **nodejs** | Same handler; custom `EvaluateReferenced` (didOpen/didClose batching, custom symbol/reference handling). Capabilities: referenced. |
+| **yaml_language_server** | **Custom handler** for `workspace/configuration` (workaround for yaml-language-server behavior). Builds `params` similarly; capabilities: referenced; custom `EvaluateReferenced` using schema + diagnostics. |
+
+So: YAML has a custom jsonrpc2 handler; Node has a custom `EvaluateReferenced` and different LSP usage; generic has extra capabilities (dependency, echo). There is no single “generic” init that fits all.
+
+**Files:**
+
+| Path | Role |
+|------|------|
+| `external-providers/generic-external-provider/pkg/server_configurations/generic/service_client.go` | Generic LSP client; referenced, dependency, echo capabilities. |
+| `external-providers/generic-external-provider/pkg/server_configurations/pylsp/service_client.go` | Pylsp client; referenced only. |
+| `external-providers/generic-external-provider/pkg/server_configurations/nodejs/service_client.go` | Node client; custom `EvaluateReferenced` (batching, didOpen/didClose). |
+| `external-providers/generic-external-provider/pkg/server_configurations/yaml_language_server/service_client.go` | YAML client; custom handler for `workspace/configuration`; custom `EvaluateReferenced` (schema + publishDiagnostics). |
+
+### 2.5 Base LSP client and capabilities (shared)
+
+- **Base client:** `lsp/base_service_client/base_service_client.go`
+  - `LSPServiceClientBase`: holds context, log, config, dialer, jsonrpc2 connection, caches, server capabilities.
+  - `NewLSPServiceClientBase(ctx, log, c, initializeHandler, initializeParams)`: unmarshals config, validates `lspServerPath`, builds temp dir if needed, creates `CmdDialer`, dials LSP, sends `initialize`, sends `initialized`, returns base.
+  - Methods: `Stop()`, `GetAllDeclarations()`, `GetAllReferences()`, `GetDependencies()` (calls external dependency binary), `Handle()` (e.g. publishDiagnostics), etc.
+- **Capabilities:** `lsp/base_service_client/base_capabilities.go`
+  - Generic `EvaluateReferenced[T]` and `EvaluateNoOp[T]` used by generic and pylsp; nodejs and yaml use their own `EvaluateReferenced` implementations.
+
+**Files:**
+
+| Path | Role |
+|------|------|
+| `lsp/base_service_client/base_service_client.go` | `LSPServiceClientBase`, `NewLSPServiceClientBase()`, LSP lifecycle and helpers. |
+| `lsp/base_service_client/base_capabilities.go` | Shared capability logic (e.g. `EvaluateReferenced[T]`). |
+
+### 2.6 Provider interfaces (core)
+
+- **BaseClient:** `Capabilities() []Capability`, `Init(ctx, log, InitConfig) (ServiceClient, InitConfig, error)`.
+- **ServiceClient:** `Evaluate()`, `Stop()`, `GetDependencies()`, `GetDependenciesDAG()`, `NotifyFileChanges()`.
+- **InternalProviderClient:** extends the client interface used by the analyzer (Init, Evaluate, deps, etc.).
+
+The generic provider’s `genericProvider` implements `BaseClient`; each builder’s `Init()` returns a type that implements `ServiceClient` (often by embedding the base and the evaluator).
+
+---
+
+## 3. Configuration and deployment touchpoints
+
+### 3.1 Provider settings (which binary, which name)
+
+- **Example config:** `provider_container_settings.json`
+  - **go:** `binaryPath: "/usr/local/bin/generic-external-provider"`, `providerSpecificConfig.lspServerName: "generic"`.
+  - **python:** Same binaryPath, `lspServerName: "pylsp"`.
+  - **nodejs:** Same binaryPath, `lspServerName: "nodejs"`.
+  - **yaml:** Uses `yq-external-provider` (different binary); the generic provider’s YAML server config is still present in code but not used by this file.
+  - **java:** `binaryPath: "/usr/local/bin/java-external-provider"` (separate binary).
+
+So today, go/python/nodejs are distinguished only by config (and the `--name` passed when the same binary is spawned).
+
+### 3.2 Build and images
+
+- **Makefile**
+  - `external-generic` builds the generic provider binary.
+  - `build-generic-provider` builds the generic provider image (with sed for golang-dependency-provider image ref).
+  - `run-external-providers-local` / `run-external-providers-pod`: run one container for java, one for yq, then **three** containers from the same generic provider image (golang-provider, nodejs, python) with different `--name` and ports.
+- **Dockerfile (repo root)**
+  - `make build` builds analyzer and providers; copies `generic-external-provider` binary to `/usr/local/bin/generic-external-provider`.
+- **external-providers/generic-external-provider/Dockerfile**
+  - Multi-stage: build generic-external-provider and gopls; base image has Node, Python, pylsp, typescript-language-server; copies in generic-external-provider and golang-dependency-provider; entrypoint is the generic binary.
+- **CI / demo**
+  - `.github/workflows/image-build.yaml`: builds generic-external-provider image.
+  - `.github/workflows/demo-testing.yml`: uses `IMG_GENERIC_PROVIDER` for go/python/nodejs demos; e2e paths under `external-providers/generic-external-provider/e2e-tests/` (golang-e2e, python-e2e, nodejs-e2e).
+
+**Files:**
+
+| Path | Role |
+|------|------|
+| `Makefile` | Build generic binary and image; run multiple generic containers with different `--name`. |
+| `Dockerfile` | Copy generic-external-provider binary into main image. |
+| `external-providers/generic-external-provider/Dockerfile` | Image that runs generic-external-provider (with runtimes for go/python/node). |
+| `.github/workflows/image-build.yaml` | Build generic-external-provider image. |
+| `.github/workflows/demo-testing.yml` | Demo/e2e using generic provider for go, python, nodejs. |
+| `provider_container_settings.json` | Default provider configs (binaryPath and initConfig per provider name). |
+
+### 3.3 Tests
+
+- Unit tests that instantiate the generic provider and/or builders:
+  - `external-providers/generic-external-provider/pkg/server_configurations/generic/service_client_test.go`
+  - `external-providers/generic-external-provider/pkg/server_configurations/pylsp/service_client_test.go`
+  - `external-providers/generic-external-provider/pkg/server_configurations/nodejs/service_client_test.go`
+  - `external-providers/generic-external-provider/pkg/server_configurations/yaml_language_server/service_client_test.go`
+- `provider/provider_test.go` uses `lspServerName` in expected provider config (generic).
+
+---
+
+## 4. What “breaking out to specific providers” would mean
+
+Conceptually:
+
+- **One provider per language** (e.g. go, python, nodejs, and optionally yaml) with its own:
+  - Binary (or at least its own `main` and provider type), and/or
+  - Clear entrypoint and no runtime switch on `lspServerName` inside one process.
+- **No generic dispatcher:** Remove the single `genericProvider` that holds a map and switches on `lspServerName` in `Init()`.
+- **Shared code:** Keep using `lsp/base_service_client` (and optionally shared capability helpers) where it makes sense; each specific provider can still embed the base and the evaluator.
+
+Reference implementation: **java-external-provider** — its own binary, own package, `java.NewJavaProvider(...)`, no dependency on the generic provider or `SupportedLanguages` map.
+
+---
+
+## 5. Affected components — full checklist
+
+### 5.1 Analyzer-lsp core (no interface change, but config and spawn logic)
+
+| Component | Current behavior | Effect of refactor |
+|-----------|------------------|---------------------|
+| `provider/lib/lib.go` — `GetProviderClient()` | Any non-builtin config → `grpc.NewGRPCClient(config, log)`. | No change to interface. Each “language” could be a different config with a different `binaryPath` (e.g. go-provider, python-provider, nodejs-provider). |
+| `provider/grpc/provider.go` — `start()` | Uses `config.BinaryPath` and `config.InitConfig[0].ProviderSpecificConfig["lspServerName"]` to set `--name` for the generic binary. | For specific providers, either: (a) keep passing a name for backward compat, or (b) remove the `--name`/`lspServerName` convention for those binaries and have each binary fixed to one language. |
+| `provider/provider.go` | Defines `BaseClient`, `ServiceClient`, `InitConfig`, `ProviderSpecificConfig`. | No change to interfaces. Provider-specific config can remain per-provider (e.g. python-specific keys without `lspServerName`). |
+| `provider/server.go` | Accepts any `BaseClient`; calls `Capabilities()` and `Init()`. | No change; each specific provider still implements `BaseClient`. |
+| `cmd/analyzer/main.go` / `cmd/dep/main.go` | Load configs and call `GetProviderClient` per config. | Config files would list separate provider entries with distinct `binaryPath` (and optionally different `name`) for go, python, nodejs. |
+
+### 5.2 Generic external provider (to be split or removed)
+
+| Component | Current behavior | Effect of refactor |
+|-----------|------------------|---------------------|
+| `external-providers/generic-external-provider/main.go` | Parses `--name`, calls `NewGenericProvider(*lspServerName, log)`, starts server. | **Remove or repurpose.** Each new provider (e.g. python-external-provider) would have its own main that constructs one provider type (e.g. Python only). |
+| `external-providers/generic-external-provider/pkg/generic_external_provider/provider.go` | Dispatches by `lspServerName`; holds one builder; returns capabilities from that builder. | **Eliminate.** Logic moves into each language-specific provider (no runtime switch). |
+| `external-providers/generic-external-provider/pkg/server_configurations/constants.go` | `SupportedLanguages` map and builder interface. | **Split or remove.** Each specific provider only knows its own builder; no shared map. |
+| `external-providers/generic-external-provider/pkg/server_configurations/generic/` | Generic (gopls) service client and builder. | Becomes the core of a **go-external-provider** (or stays as “generic” if one binary remains for generic LSPs). |
+| `external-providers/generic-external-provider/pkg/server_configurations/pylsp/` | Pylsp service client and builder. | Becomes the core of **python-external-provider** (or pylsp-external-provider). |
+| `external-providers/generic-external-provider/pkg/server_configurations/nodejs/` | Node service client and builder. | Becomes the core of **nodejs-external-provider**. |
+| `external-providers/generic-external-provider/pkg/server_configurations/yaml_language_server/` | YAML service client and builder. | Either a **yaml-external-provider** (if not using yq) or removed if yq remains the only YAML path. |
+
+### 5.3 Base LSP client (shared)
+
+| Component | Current behavior | Effect of refactor |
+|-----------|------------------|---------------------|
+| `lsp/base_service_client/base_service_client.go` | Shared base for all LSP-based service clients. | **Keep.** All specific providers can keep embedding and using it. |
+| `lsp/base_service_client/base_capabilities.go` | Shared capability functions. | **Keep.** Language providers that use the same behavior can keep calling these. |
+
+### 5.4 Configuration and deployment
+
+| Component | Current behavior | Effect of refactor |
+|-----------|------------------|---------------------|
+| `provider_container_settings.json` | go, python, nodejs share `binaryPath: ".../generic-external-provider"` and differ by `lspServerName`. | **Update.** Point go to go-external-provider binary, python to python-external-provider, nodejs to nodejs-external-provider (or keep one “generic” binary for go only and add python/nodejs binaries). |
+| `Makefile` | Builds one generic binary; runs multiple containers with same image and different `--name`. | **Update.** Build and run separate images/containers per provider (or one image with multiple binaries). |
+| Root `Dockerfile` | Copies single generic-external-provider binary. | **Update.** Copy each new provider binary (or a single multi-binary image). |
+| `external-providers/generic-external-provider/Dockerfile` | Single image with generic binary + runtimes. | **Option A:** Replace with separate Dockerfiles per language. **Option B:** One image that contains multiple binaries (go, python, nodejs) and an entrypoint that selects by env/arg. |
+| `.github/workflows/image-build.yaml` | Builds generic-external-provider image. | **Update.** Build new provider images (or one multi-provider image). |
+| `.github/workflows/demo-testing.yml` | Uses IMG_GENERIC_PROVIDER for go/python/nodejs. | **Update.** Use the appropriate image per demo (or one image with multiple binaries). |
+| `provider/testdata/*.yaml` / `*.json` | Some reference generic-external-provider binaryPath. | **Update** if tests assume a single generic binary; otherwise leave as-is for backward compat tests. |
+| `debug/debug.Dockerfile` | Builds and copies generic-external-provider. | **Update** if debug image should include specific providers. |
+
+### 5.5 Tests
+
+| Component | Current behavior | Effect of refactor |
+|-----------|------------------|---------------------|
+| `external-providers/generic-external-provider/pkg/server_configurations/*/service_client_test.go` | Use `generic_external_provider.NewGenericProvider("...", log)` and/or builders. | **Move** to the corresponding new provider packages; remove dependency on generic provider and constants map. |
+| `provider/provider_test.go` | Expects `lspServerName` in provider config. | **Adjust** if tests are generic-provider-specific; keep or duplicate for new providers as needed. |
+
+### 5.6 Documentation
+
+| Component | Current behavior | Effect of refactor |
+|-----------|------------------|---------------------|
+| `external-providers/generic-external-provider/docs/README.md` | Describes generic provider and how to add new service clients via the map. | **Rewrite** to describe either (a) the remaining “generic” provider (e.g. go only) or (b) the pattern for language-specific providers. |
+| `docs/experimental/python-provider.md` | References generic-external-provider and pylsp. | **Update** to point to python-external-provider (or new layout). |
+| Any other docs that reference “generic provider” or “SupportedLanguages” | — | **Update** to reflect new provider layout. |
+
+---
+
+## 6. Intricacies and risks
+
+1. **Capabilities before Init:** The analyzer calls `Capabilities()` on the gRPC client (which forwards to the provider process) before calling `Init()`. So each process must advertise the right capabilities at startup. Today that’s done by locking the generic provider to one `lspServerName` via `--name`. With separate binaries, each binary naturally advertises one set of capabilities.
+
+2. **InitConfig and lspServerName:** Today, `Init()` can change the builder if `ProviderSpecificConfig["lspServerName"]` differs from the provider’s `lspServerName`. After the refactor, that switch is unnecessary for single-language providers; config can be simplified (e.g. drop `lspServerName` for python/nodejs/go-specific providers).
+
+3. **Shared base and evaluator:** All four server configs depend on `lsp/base_service_client` and the evaluator pattern. Moving code into new repos/packages should preserve this; only the “dispatcher” (generic provider + constants map) goes away.
+
+4. **YAML:** The default container settings use `yq-external-provider` for yaml, not the generic provider’s yaml_language_server. So “breaking out” YAML could mean either (a) a new yaml-external-provider that uses the current yaml_language_server code, or (b) leaving YAML to yq only and deprecating the yaml_language_server config in the generic provider.
+
+5. **Backward compatibility:** If we keep a “generic” binary that only supports the current “generic” (gopls) client, existing configs that use `binaryPath: ".../generic-external-provider"` with `lspServerName: "generic"` could keep working. Configs that use the same binary with `pylsp` or `nodejs` would need to be updated to new binaries.
+
+6. **Build and CI:** Splitting into multiple binaries/images increases the number of build artifacts and possibly CI jobs. Alternative: one image with multiple binaries and an entrypoint that chooses by `--name` or env (minimal change to run scripts but still allows separate codebases per language).
+
+---
+
+## 7. Summary table of file-level impact
+
+| Area | Files to modify / move / remove |
+|------|----------------------------------|
+| **Provider core** | `provider/grpc/provider.go` (start logic for `--name`); optionally `provider/provider.go` if any generic-specific validation exists. |
+| **Generic provider** | Remove or shrink `generic-external-provider`: `main.go`, `pkg/generic_external_provider/provider.go`, `pkg/server_configurations/constants.go`; move each server_configurations/* into a corresponding new provider. |
+| **New providers** | New dirs: e.g. `go-external-provider`, `python-external-provider`, `nodejs-external-provider` (each with main, provider type, one server config). |
+| **Base** | `lsp/base_service_client/*` — keep as-is. |
+| **Config** | `provider_container_settings.json`; testdata in `provider/testdata`. |
+| **Build / CI** | `Makefile`, root `Dockerfile`, `external-providers/generic-external-provider/Dockerfile`, `.github/workflows/image-build.yaml`, `.github/workflows/demo-testing.yml`, `debug/debug.Dockerfile`. |
+| **Tests** | All `server_configurations/*/service_client_test.go`; `provider/provider_test.go` if it asserts on generic behavior. |
+| **Docs** | `external-providers/generic-external-provider/docs/README.md`, `docs/experimental/python-provider.md`, any other references to generic provider or SupportedLanguages. |
+
+This document is intended as the single reference for the refactoring scope and touchpoints; it does not prescribe an order of implementation or a specific design for the new provider binaries/images (e.g. one image vs many).


### PR DESCRIPTION
- Proposal for refactoring the generic provider into their own specific providers (python, nodejs, ...)
- Also committed additional information regarding the current status of the generic provider, from which the enhancement was generated.
- Some open questions appear that I have left there:
  - YAML provider strategy: I guess there are some traces of yaml provider being generic, but we already have an independent yaml provider, if I'm not mistaken.
  - Image topology: we'll be generating individual images
  - Backwards compatibility is a good point, although I guess most people using this are doing so through konveyor/kantra, so probably not a big concern

Addresses https://github.com/konveyor/analyzer-lsp/issues/1013

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed enhancement docs describing a planned refactor from a single generic provider to language-specific providers (Go, Python, Node), YAML handling updates, test/CI and packaging implications, transition and upgrade strategies, risks, and implementation notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->