### PR TITLE
Hub OIDC Provider

### DIFF
--- a/enhancements/hub-oidc-provider/DESIGN.md
+++ b/enhancements/hub-oidc-provider/DESIGN.md
@@ -194,7 +194,7 @@ sequenceDiagram
 
     Note over UI,Hub: Local Authorization Code Flow (No Consent)
 
-    UI->>Hub: GET /oauth2/authorize<br>?client_id=...&scope=openid profile email
+    UI->>Hub: GET /oidc/authorize<br>?client_id=...&scope=openid profile email
     activate Hub
 
     Hub->>User: Redirect to Login Page
@@ -223,7 +223,7 @@ sequenceDiagram
 
     Note over UI,Hub: Back-channel token exchange
 
-    UI->>Hub: POST /oauth2/token<br>grant_type=authorization_code + code_verifier
+    UI->>Hub: POST /oidc/token<br>grant_type=authorization_code + code_verifier
     activate Hub
 
     Hub-->>UI: Access Token + ID Token + Refresh Token<br>(signed by Hub keys, containing role-based scopes)
@@ -247,7 +247,7 @@ sequenceDiagram
 
     Note over UI,Hub: Authorization Code Flow starts
 
-    UI->>Hub: GET /oauth2/authorize<br>?client_id=...&scope=...&idp=google
+    UI->>Hub: GET /oidc/authorize<br>?client_id=...&scope=...&idp=google
     activate Hub
 
     Hub->>User: Redirect to External Login<br>(or show IdP selector)
@@ -260,7 +260,7 @@ sequenceDiagram
     ExternalIdP-->>User: Redirect back to Hub Provider<br>with authorization code
     deactivate ExternalIdP
 
-    User->>Hub: Callback with code<br>(/oauth2/authorize/{callback_id}?code=...)
+    User->>Hub: Callback with code<br>(/oidc/authorize/{callback_id}?code=...)
 
     Hub->>ExternalIdP: POST /token (exchange code)
     activate ExternalIdP
@@ -289,7 +289,7 @@ sequenceDiagram
 
     Note over UI,Hub: Back-channel token exchange
 
-    UI->>Hub: POST /oauth2/token<br>grant_type=authorization_code + code_verifier
+    UI->>Hub: POST /oidc/token<br>grant_type=authorization_code + code_verifier
     activate Hub
 
     Hub-->>UI: Access Token + ID Token + Refresh Token<br>(signed by Hub keys, with local scopes/claims)
@@ -314,7 +314,7 @@ sequenceDiagram
     Note over Hub,LDAP: Authentication uses Search + Bind pattern<br>Group retrieval via memberOf (AD) or group search
 
     %% === Initial Login Flow (Authorization Code Flow) ===
-    UI->>Hub: GET /authorize (client_id, scope=openid profile email, redirect_uri...)
+    UI->>Hub: GET /oidc/authorize (client_id, scope=openid profile email, redirect_uri...)
     Hub-->>UI: Redirect to Hub Login Page
 
     UI->>Hub: POST Login (username + password)
@@ -340,7 +340,7 @@ sequenceDiagram
 
     deactivate Hub
 
-    UI->>Hub: POST /token (grant_type=authorization_code, code=...)
+    UI->>Hub: POST /oidc/token (grant_type=authorization_code, code=...)
     activate Hub
     Hub->>Hub: Validate code + issue tokens
     Hub-->>UI: Access Token (JWT with roles/scopes) + ID Token + Refresh Token

--- a/enhancements/hub-oidc-provider/DESIGN.md
+++ b/enhancements/hub-oidc-provider/DESIGN.md
@@ -1,0 +1,556 @@
+# Design Details: Builtin Auth
+
+This document contains the detailed design specifications for the builtin Auth enhancement.
+
+## Architecture Overview
+
+The Hub will function as an OIDC provider with the following components:
+- User and role-based access control (RBAC) managed in the Hub inventory
+- Support for local authentication or delegation to external providers (OIDC, LDAP/Active Directory)
+- API key-based authentication for programmatic access
+- Token issuance, validation, and revocation
+
+## Routes and Endpoints
+
+### Resource Management Endpoints
+
+| Method        | Path                 | Purpose                        |
+|---------------|----------------------|--------------------------------|
+| ANY           | /auth/users          | User collection                |
+| ANY           | /auth/roles          | Roles collection               |
+| GET           | /auth/permissions    | Permission collection          |
+| GET \| DELETE | /auth/tokens         | Issued tokens                  |
+| ANY           | /auth/apikeys        | API-Key collection             |
+| GET           | /auth/idp/identities | Remote IDP identity collection |
+
+
+### Standard OIDC Endpoints
+
+| Method | Path                              | Purpose                                                                                        |
+|--------|-----------------------------------|------------------------------------------------------------------------------------------------|
+| GET    | /.well-known/openid-configuration | Discovery document – Tells clients all the endpoints, supported scopes, grant types, etc.      |
+| GET    | /oidc/authorize                   | Authorization Endpoint – Starts the login flow (shows login form or redirects to external IdP) |
+| POST   | /oidc/token                       | Token Endpoint – Exchanges authorization code for access_token + id_token + refresh_token      |
+| GET    | /oidc/jwks                        | JSON Web Key Set – Public keys used by clients to verify your JWT signatures                   |
+| GET    | /oidc/userinfo                    | UserInfo Endpoint – Returns user claims (optional, but commonly used)                          |
+| POST   | /oidc/introspect                  | Token Introspection – Allows resource servers to validate opaque tokens (optional)             |
+| POST   | /oidc/revoke                      | Token Revocation – Allows clients to revoke refresh tokens (optional but recommended)          |
+
+## Data Model
+
+### Entity Definitions
+
+**Entities:**
+- **User** - Known users in the system
+- **Role** - Named groups of permissions (scopes)
+- **Permission** - Named permissions mapped to scopes
+- **IdpIdentity** - Identities authenticated by remote IdP provider. Contains the refresh token.
+- **Token** - Issued (valid) tokens
+- **APIKey** - Issued (valid) API-Keys
+
+### Entity Relationship Diagram
+
+```mermaid
+erDiagram
+    USER }o--o{ ROLE : "granted"
+    ROLE }o--o{ PERMISSION : "has"
+    USER ||--o{ API_KEY : "owns"
+    TASK ||--o{ API_KEY : "owns"
+    IDP_IDENTITY ||--|| USER : "EXTERNAL identity"
+    IDP_IDENTITY ||--|| TOKEN : "delegated authentication"
+
+    USER {
+        uint id PK
+        string userid "unique"
+        string password "encrypted"
+        string email "unique"
+    }
+
+    ROLE {
+        uint id PK
+        string name "unique"
+    }
+
+    PERMISSION {
+        uint id PK
+        string name "human readable name"
+        string scope "scope"
+    }
+
+    API_KEY {
+        uint id PK
+        uint user_id FK
+        uint task_id FK
+        string digest "unique, hashed-secret"
+        datetime expiration
+    }
+
+    IDP_IDENTITY {
+        uint id PK
+        uint user_id FK
+        string provider "Ex: google"
+        string subject
+        string refresh_token "(encrypted)"
+        datetime expiration
+        datetime last_authenticated
+        datetime last_refreshed
+    }
+    
+    TOKEN {
+        uint id PK
+        uint user_id FK
+        uint idp_identity_id FK "0 = none"
+        string jti "jwt id"
+        datetime expiration
+    }
+    
+    TASK {
+    uint id PK
+    }
+```
+
+### Implementation Notes
+
+- The Token table contains hub-issued tokens only
+- The Token._expiration_ column is mainly used for reaping expired tokens
+- API-Keys are stored in the DB but cached in memory for performance and to mitigate DB pressure
+
+## Authentication Flows
+
+### Local Authentication Flow
+
+The standard OIDC authorization code flow with local credential verification:
+
+```mermaid
+sequenceDiagram
+    participant UI as UI (Client Application)
+    participant Hub as Hub Provider<br>(OIDC Provider)
+    participant User as User
+    participant DB as Database<br>(Users + Roles)
+
+    Note over UI,Hub: Local Authorization Code Flow (No Consent)
+
+    UI->>Hub: GET /oauth2/authorize<br>?client_id=...&scope=openid profile email
+    activate Hub
+
+    Hub->>User: Redirect to Login Page
+    User->>Hub: Shows Login Form
+
+    User->>Hub: POST login credentials<br>(username + password)
+    activate Hub
+
+    Hub->>DB: Authenticate User<br>(check username + password)
+    DB-->>Hub: User record + associated Roles
+
+    alt Invalid Credentials
+        Hub->>User: Show Login Page with Error
+        deactivate Hub
+    else Valid Credentials
+        Hub->>Hub: Set Subject (username)
+
+        Hub->>DB: Get User Roles & Scopes
+        DB-->>Hub: List of scopes from roles
+
+        Hub->>Hub: Apply Authorization Layer<br>(merge requested scopes + role-based scopes)
+
+        Hub-->>UI: Redirect back with authorization code
+        deactivate Hub
+    end
+
+    Note over UI,Hub: Back-channel token exchange
+
+    UI->>Hub: POST /oauth2/token<br>grant_type=authorization_code + code_verifier
+    activate Hub
+
+    Hub-->>UI: Access Token + ID Token + Refresh Token<br>(signed by Hub keys, containing role-based scopes)
+
+    deactivate Hub
+
+    Note over UI: UI now has tokens issued by Hub Provider<br>with local user identity + authorization from roles
+```
+
+### External OIDC Provider Flow
+
+When an external OIDC provider (e.g., Google, Keycloak) is configured, the Hub acts as a broker:
+
+```mermaid
+sequenceDiagram
+    participant UI as UI (Client Application)
+    participant Hub as Hub <br>(OIDC Broker)
+    participant ExternalIdP as External IdP<br>(e.g. Google)
+    participant User as User
+    participant DB as Database<br>(Users + Roles)
+
+    Note over UI,Hub: Authorization Code Flow starts
+
+    UI->>Hub: GET /oauth2/authorize<br>?client_id=...&scope=...&idp=google
+    activate Hub
+
+    Hub->>User: Redirect to External Login<br>(or show IdP selector)
+    User->>ExternalIdP: Browser redirects to Google login page
+    activate ExternalIdP
+
+    ExternalIdP->>User: Show Google login / consent screen
+    User->>ExternalIdP: Authenticates (username/password or SSO)
+
+    ExternalIdP-->>User: Redirect back to Hub Provider<br>with authorization code
+    deactivate ExternalIdP
+
+    User->>Hub: Callback with code<br>(/oauth2/authorize/{callback_id}?code=...)
+
+    Hub->>ExternalIdP: POST /token (exchange code)
+    activate ExternalIdP
+    ExternalIdP-->>Hub: ID Token + Access Token
+    deactivate ExternalIdP
+
+    Hub->>ExternalIdP: GET UserInfo (optional)
+    ExternalIdP-->>Hub: User claims (sub, email, name, ...)
+
+    Hub->>DB: Lookup or Create User<br>(map Google sub/email → local user)
+    activate DB
+    DB-->>Hub: Local user record + associated Roles
+
+    Hub->>Hub: Apply Authorization Layer<br>(add role-based scopes, custom claims)
+    deactivate DB
+
+    alt Consent Required
+        Hub->>User: Show Consent Screen<br>("Allow this app to access ...")
+        User->>Hub: User approves (or denies)
+    else Consent Already Given
+        Note right of Hub: Skip consent
+    end
+
+    Hub-->>UI: Redirect back with authorization code
+    deactivate Hub
+
+    Note over UI,Hub: Back-channel token exchange
+
+    UI->>Hub: POST /oauth2/token<br>grant_type=authorization_code + code_verifier
+    activate Hub
+
+    Hub-->>UI: Access Token + ID Token + Refresh Token<br>(signed by Hub keys, with local scopes/claims)
+
+    deactivate Hub
+
+    Note over UI: UI now has tokens issued by the Hub Provider<br>containing both external identity + local authorization (roles/scopes)
+```
+
+### LDAP / Active Directory Flow
+
+LDAP authentication uses the search + bind pattern with group-based role mapping:
+
+```mermaid
+sequenceDiagram
+    participant UI as UI / Client
+    participant Hub as Hub Provider (OIDC)
+    participant LDAP as LDAP / Active Directory
+    participant ProtectedAPI as Protected API
+    participant DB as Database
+
+    Note over Hub,LDAP: Authentication uses Search + Bind pattern<br>Group retrieval via memberOf (AD) or group search
+
+    %% === Initial Login Flow (Authorization Code Flow) ===
+    UI->>Hub: GET /authorize (client_id, scope=openid profile email, redirect_uri...)
+    Hub-->>UI: Redirect to Hub Login Page
+
+    UI->>Hub: POST Login (username + password)
+    activate Hub
+
+    Hub->>LDAP: 1. Search for user (by sAMAccountName / uid) → get DN
+    LDAP-->>Hub: User DN + basic attributes
+
+    Hub->>LDAP: 2. Bind as user DN with provided password
+    LDAP-->>Hub: Bind Success / Failure
+
+    alt Authentication Failed
+        Hub-->>UI: Login failed → show error
+    else Authentication Succeeded
+        Hub->>LDAP: 3. Fetch groups (memberOf attribute or group search)
+        LDAP-->>Hub: List of group DNs / CNs (e.g. IT-Admins, Finance-Users...)
+
+        Hub->>Hub: Apply YAML group rules (any/and + glob matching)<br>→ Compute internal roles & scopes
+        Hub->>DB: Create / update local user session (optional: store last groups, roles)
+
+        Hub-->>UI: Redirect back with authorization code
+    end
+
+    deactivate Hub
+
+    UI->>Hub: POST /token (grant_type=authorization_code, code=...)
+    activate Hub
+    Hub->>Hub: Validate code + issue tokens
+    Hub-->>UI: Access Token (JWT with roles/scopes) + ID Token + Refresh Token
+    deactivate Hub
+
+    Note over Hub,DB: Access Token contains pre-computed roles/scopes from LDAP groups
+
+    %% === Subsequent API Requests ===
+    UI->>ProtectedAPI: Request with Hub access_token
+    activate ProtectedAPI
+
+    ProtectedAPI->>ProtectedAPI: Verify Hub JWT signature + claims (roles/scopes)
+    ProtectedAPI->>DB: Optional: Lookup user + session metadata
+
+    alt Re-validation / Group Refresh Enabled
+        ProtectedAPI->>Hub: Optional introspection or /userinfo (or direct LDAP check if designed)
+        Hub->>LDAP: Re-fetch current groups (if needed)
+        Hub->>Hub: Re-apply rules → updated roles
+        Hub-->>ProtectedAPI: Updated claims / decision
+    else Simple Mode (no re-validation)
+        ProtectedAPI->>ProtectedAPI: Check local roles/scopes from token
+    end
+
+    alt Access Allowed
+        ProtectedAPI-->>UI: 200 OK + response
+    else Access Denied
+        ProtectedAPI-->>UI: 403 Forbidden
+    end
+
+    deactivate ProtectedAPI
+```
+
+## Token Validation
+
+### Standard Token Validation Flow
+
+Supports JWT (RSA and deprecated HMAC) and API keys:
+
+```mermaid
+sequenceDiagram
+    participant UI as UI / API Client
+    participant ProtectedAPI as Protected API
+    participant Hub as Hub Provider<br>(OIDC Provider)
+    participant DB as API Key Database / Store
+
+    Note over UI,ProtectedAPI: Bearer Token Validation Flow<br>(JWT RSA + JWT HMAC deprecated + API Keys)
+
+    UI->>ProtectedAPI: GET /api/projects<br>Authorization: Bearer <token>
+    activate ProtectedAPI
+
+    ProtectedAPI->>ProtectedAPI: 1. Extract Bearer token
+
+    alt Token is a JWT (contains exactly two '.' characters)
+        ProtectedAPI->>ProtectedAPI: 2. Decode JWT Header (read alg)
+
+        alt alg starts with "RS" (RSA)
+            ProtectedAPI->>ProtectedAPI: 3a. Verify RSA Signature using Hub JWKS
+            note right of ProtectedAPI: Recommended
+        else alg starts with "HS" (HMAC)
+            ProtectedAPI->>ProtectedAPI: 3b. Verify HMAC Signature using shared secret
+            note right of ProtectedAPI: Deprecated but supported for backwards compat
+        else Unsupported algorithm
+            ProtectedAPI-->>UI: 401 Unauthorized
+            note right of ProtectedAPI: Reject unknown algs including "none"
+        end
+
+        ProtectedAPI->>ProtectedAPI: 4. Validate Standard JWT Claims (iss, aud, exp, etc.)
+        ProtectedAPI->>ProtectedAPI: 5. Extract Claims (sub, scope, roles...)
+
+    else Token is NOT a valid JWT → Treat as API Key
+        ProtectedAPI->>DB: 2b. Lookup API Key in DB
+        activate DB
+        DB-->>ProtectedAPI: Key record (active?, scopes/permissions)
+        deactivate DB
+
+        alt API Key invalid or revoked
+            ProtectedAPI-->>UI: 401 Unauthorized
+        else API Key valid
+            ProtectedAPI->>ProtectedAPI: 3c. Map DB permissions to scopes
+        end
+    end
+
+    alt Token validation failed
+        ProtectedAPI-->>UI: 401 Unauthorized
+    else Token is valid
+        ProtectedAPI->>ProtectedAPI: 6. Perform Authorization Check<br>(unified scope check)
+        alt Authorization fails
+            ProtectedAPI-->>UI: 403 Forbidden
+        else Authorization passed
+            ProtectedAPI-->>UI: 200 OK + Response
+        end
+    end
+
+    deactivate ProtectedAPI
+
+    Note over ProtectedAPI: Key Notes<br/>RSA via JWKS is strongly preferred.<br/>HMAC is deprecated but honored for backwards compatibility.<br/>API Keys are mapped to the same scope model as JWTs.<br/>Always reject alg="none" and unknown algorithms.<br/>Consider logging HMAC usage for migration tracking.
+```
+
+### External IdP Token Validation
+
+For users authenticated via external providers, validation includes refresh token checks:
+
+```mermaid
+sequenceDiagram
+    participant UI as UI / Client
+    participant Hub as Hub Provider
+    participant ProtectedAPI as Protected API
+    participant DB as Database
+    participant ExternalIdP as External IdP (Google, etc.)
+
+    Note over Hub,DB: During initial login: Store external refresh_token linked to local user
+
+    UI->>ProtectedAPI: Request with Hub access_token
+    activate ProtectedAPI
+
+    ProtectedAPI->>ProtectedAPI: Verify Hub JWT signature + claims
+    ProtectedAPI->>DB: Lookup user + stored external refresh_token
+
+    alt Re-validation Enabled
+        ProtectedAPI->>ExternalIdP: Attempt refresh<br>(POST /token with refresh_token)
+        ExternalIdP-->>ProtectedAPI: Success → new external tokens<br>OR Failure (invalid_grant / revoked)
+        
+        alt External Refresh Failed (Revoked)
+            ProtectedAPI->>ProtectedAPI: Mark session as invalid / force re-login
+            ProtectedAPI-->>UI: 401 Unauthorized + prompt to re-authenticate
+        else External Refresh Succeeded
+            ProtectedAPI->>ProtectedAPI: Optional: Update stored tokens
+            ProtectedAPI->>ProtectedAPI: Check local roles/scopes
+            ProtectedAPI-->>UI: 200 OK
+        end
+    else No Re-validation (simple mode)
+        ProtectedAPI-->>UI: 200 OK (until Hub token expires)
+    end
+
+    deactivate ProtectedAPI
+```
+
+## API Key Authentication
+
+### Generation
+
+API keys are generated via POST to `/auth/apikey` and inherit permissions from the creating user's roles.
+
+**Request:**
+```yaml
+POST /auth/apikey
+
+expiration: # OPTIONAL (datetime)
+```
+
+**Response:**
+```yaml
+id: 18
+expiration: # OPTIONAL
+key: cvP1sjff7_X2dCEIzUPf8f0IzKSbwiSDf1dZChZuRxY
+```
+
+**Implementation details:**
+- Keys are 256-bit base64URL-encoded strings
+- The key is stored as a hashed digest in the database
+- Permissions (scopes) are inherited from the user's role assignments at creation time
+- Keys can have optional expiration dates
+
+### Authentication
+
+API keys are presented as Bearer tokens:
+```
+Authorization: Bearer <key>
+```
+
+**Validation process:**
+1. Extract the key from the Authorization header
+2. Hash and lookup the stored key in the database
+3. Verify the key is not expired or revoked
+4. Retrieve associated permissions (scopes)
+5. Authorize endpoint access based on scopes
+
+### Addon Tokens
+
+The task manager and addon API authorization will be refactored to use API keys instead of custom JWT token generation:
+- New tasks will be configured with API keys for authentication
+- Legacy support: Tokens with `SigningMethod=HMAC` will still be honored for backwards compatibility with in-flight tasks
+- This provides a unified authentication mechanism across all programmatic access
+
+## LDAP/Active Directory Group Mapping
+
+### Policy Schema
+
+The group-to-role mapping policy is expressed in YAML and can be managed through the UI. The policy defines how LDAP/AD group memberships map to internal roles.
+
+**Structure:**
+- Each mapping rule contains a conditional expression (`any` or `and`) and a list of `roles` to assign
+- **`any`**: User matches if they belong to **at least one** of the listed groups (logical OR)
+- **`and`**: User matches if they belong to **all** of the listed groups (logical AND)
+- **`roles`**: List of internal role names to assign when the condition matches
+
+**Evaluation rules:**
+- All rules are evaluated for each user during authentication
+- A user may match multiple rules and accumulate roles from all matches
+- The final set of permissions (scopes) is the union of all assigned roles
+- Group names are matched exactly (case-sensitive) against groups returned from LDAP/AD
+
+### Example Policy
+
+```yaml
+groups:
+  # Administrators
+  - any:
+      - Engineering-Admins
+      - Platform-Admins
+      - IT-Admins
+      - SEC-Global-Admins
+      - Infrastructure-Admins
+    roles:
+      - admin
+
+  # Managers
+  - and:
+      - Engineering
+      - Engineering-Managers
+      - Managers
+    roles:
+      - manager
+
+  # Architects
+  - any:
+      - Engineering-Architects
+      - Principal-Architects
+      - Solution-Architects
+      - Tech-Leads
+    roles:
+      - architect
+
+  # Migrators
+  - any:
+      - Engineering-Migration-Team
+      - Database-Admins
+      - SRE-Migration
+      - Platform-Migration
+      - Data-Migration-Team
+    roles:
+      - migrator
+
+  # High-privilege production access
+  - and:
+      - Engineering
+      - Prod-Admins
+    roles:
+      - admin
+      - migrator
+```
+
+## Token Revocation
+
+Tokens and API keys can be explicitly revoked:
+
+- **DELETE /auth/tokens/:id** - Revokes a specific token (effective on next refresh)
+- **DELETE /auth/apikeys/:id** - Revokes a specific API key (effective immediately)
+
+Revocation is tracked in the database to ensure revoked credentials are not accepted.
+
+## Configuration Management
+
+### Client Configuration
+
+OIDC clients are loaded from a ConfigMap seeded by the operator. This allows the operator to manage client registrations without requiring database access.
+
+### Login UI
+
+The login page UI fragment is read from a ConfigMap managed by the operator. This enables:
+- Branding customizations managed by the operator
+- Consistent UI updates across installations
+- Separation of presentation from application logic
+
+### Security
+
+All sensitive information (passwords, refresh tokens) is stored encrypted in the database. API keys are stored as cryptographic hashes (digests) only, never in plain text.

--- a/enhancements/hub-oidc-provider/DESIGN.md
+++ b/enhancements/hub-oidc-provider/DESIGN.md
@@ -611,7 +611,7 @@ groups:
 Tokens and grants can be explicitly revoked:
 
 - **DELETE /auth/grants/:id** - Revokes a specific OIDC grant (effective on next refresh)
-- **DELETE /auth/tokens/:id** - Revokes a specific token (JWT, PAT, etc., effective immediately)
+- **DELETE /auth/tokens/:id** - Revokes a specific (PAT) token (effective immediately)
 
 Revocation is tracked in the database via the Token.revoked timestamp field to ensure revoked
 credentials are not accepted.
@@ -632,6 +632,8 @@ This unified approach allows the operator to manage all OIDC configuration atomi
 requiring database access. The Secret is mounted into the Hub at `/etc/hub/` and read at startup
 (file: `/etc/hub/oidc.yaml`).
 
+#### Hub
+
 Example structure:
 ```yaml
 apiVersion: v1
@@ -642,9 +644,30 @@ type: Opaque
 stringData:
   oidc.yaml: |
     clients:
-      - clientId: konveyor-ui
+      - clientId: web-ui
         clientSecret: <secret>
-        redirectURIs: [...]
+        grants:
+        - authorization_code
+        - refresh_token
+        redirectURIs:
+        - localhost:8080                               # web-app
+        - https://keycloak.example.com/realms/konveyor # (optional) federated oidc
+        scopes: [...]
+      - clientId: kai-ide
+        grants:
+        - authorization_code
+        - refresh_token
+        redirectURIs:
+        - vscode://publisher.extension/auth
+        - https://keycloak.example.com/realms/konveyor # (optional) federated oidc
+        scopes: [...]
+      - clientId: cli
+        grants:
+        - urn:ietf:params:oauth:grant-type:device_code
+        - authorization_code
+        - refresh_token
+        redirectURIs:
+        - http://localhost:*  # unused for DAC (device access grant)
         scopes: [...]
 
     idp:
@@ -655,6 +678,37 @@ stringData:
         clientSecret: "<secret>"
         scopes: [...]
 ```
+
+#### Clients
+
+**WEB-UI:**
+
+| setting       | value                               |
+|---------------|-------------------------------------|
+| issuer        | hub-service-address/oidc            |
+| client_id     | web-ui                              |
+| client_secret | ABCDE                               |
+| redirect_uris | http://localhost:*                  |
+| scope         | openid profile email offline_access |
+
+**IDE:**
+
+| setting       | value                               |
+|---------------|-------------------------------------|
+| issuer        | https://konveyor-ingress/hub/oidc   |
+| client_id     | web-ui                              |
+| redirect_uris | vscode://publisher.extension/auth   |
+| scope         | openid profile email offline_access |
+| response_type | code                                |
+| usePKCE       | true                                |
+
+**CLI (binding):**
+
+| setting   | value                    |
+|-----------|--------------------------|
+| issuerURL | hub-service-address/oidc |
+| clientID  | cli                      |
+
 
 ### Login UI
 

--- a/enhancements/hub-oidc-provider/DESIGN.md
+++ b/enhancements/hub-oidc-provider/DESIGN.md
@@ -712,7 +712,7 @@ stringData:
 
 ### Login UI
 
-The login page UI fragment is read from a ConfigMap managed by the operator. This enables:
+The login page UI fragment is read from a file selected by build tooling. This enables:
 - Branding customizations managed by the operator
 - Consistent UI updates across installations
 - Separation of presentation from application logic

--- a/enhancements/hub-oidc-provider/DESIGN.md
+++ b/enhancements/hub-oidc-provider/DESIGN.md
@@ -606,9 +606,38 @@ Revocation is tracked in the database via the Token.revoked timestamp field to e
 
 ## Configuration Management
 
-### Client Configuration
+### OIDC Configuration
 
-OIDC clients are loaded from a ConfigMap seeded by the operator. This allows the operator to manage client registrations without requiring database access.
+All OIDC-related configuration is loaded from a single Secret (`hub-oidc`) seeded by the operator. This Secret contains:
+
+- **Client registrations** (`clients:` section): Registered OIDC clients (UI, CLI tools, etc.) with their credentials, redirect URIs, and allowed scopes
+- **External IdP configurations** (`idp:` section): External identity provider configurations (Keycloak, Google, LDAP, etc.) with connection details and credentials
+
+This unified approach allows the operator to manage all OIDC configuration atomically without requiring database access. The Secret is mounted into the Hub at `/etc/hub/` and read at startup (file: `/etc/hub/oidc.yaml`).
+
+Example structure:
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hub-oidc
+type: Opaque
+stringData:
+  oidc.yaml: |
+    clients:
+      - clientId: konveyor-ui
+        clientSecret: <secret>
+        redirectURIs: [...]
+        scopes: [...]
+
+    idp:
+      - kind: oidc
+        name: keycloak
+        issuer: "https://keycloak.example.com/realms/konveyor"
+        clientId: "tackle-hub"
+        clientSecret: "<secret>"
+        scopes: [...]
+```
 
 ### Login UI
 

--- a/enhancements/hub-oidc-provider/DESIGN.md
+++ b/enhancements/hub-oidc-provider/DESIGN.md
@@ -44,69 +44,140 @@ The Hub will function as an OIDC provider with the following components:
 - **Role** - Named groups of permissions (scopes)
 - **Permission** - Named permissions mapped to scopes
 - **IdpIdentity** - Identities authenticated by remote IdP provider. Contains the refresh token.
-- **Token** - Issued (valid) tokens
-- **PAT** - Issued (valid) Personal Access Tokens
+- **Client** - OIDC client registrations
+- **Grant** - OIDC authorization grants (authorization codes and refresh tokens)
+- **Token** - Issued tokens (JWTs, PATs, and other token types differentiated by Kind field)
+- **RsaKey** - RSA signing keys for JWT tokens
 
 ### Entity Relationship Diagram
 
 ```mermaid
 erDiagram
-    USER }o--o{ ROLE : "granted"
-    ROLE }o--o{ PERMISSION : "has"
-    USER ||--o{ PAT : "owns"
-    TASK ||--o{ PAT : "owns"
-    IDP_IDENTITY ||--|| USER : "EXTERNAL identity"
-    IDP_IDENTITY ||--|| TOKEN : "delegated authentication"
+    USER }o--o{ ROLE : "assigned via UserRole"
+    ROLE }o--o{ PERMISSION : "has via RolePermission"
+    USER ||--o{ TOKEN : "owns"
+    TASK ||--o{ TOKEN : "owns"
+    CLIENT ||--o{ GRANT : "has"
+    GRANT ||--o{ TOKEN : "exchanges for"
+    TOKEN }o--o| GRANT : "references"
+    TOKEN }o--o| IDP_IDENTITY : "authenticated via"
 
     USER {
         uint id PK
-        string userid "unique"
-        string password "bcrypt hash"
-        string email "unique"
+        time create_time
+        string create_user
+        string update_user
+        string subject "indexed, not null"
+        string userid "unique, not null"
+        string password "bcrypt hash, not null"
+        string email "indexed, not null"
     }
 
     ROLE {
         uint id PK
-        string name "unique"
+        time create_time
+        string create_user
+        string update_user
+        string name "indexed, not null"
     }
 
     PERMISSION {
         uint id PK
-        string name "human readable name"
-        string scope "scope"
+        time create_time
+        string create_user
+        string update_user
+        string name "not null"
+        string scope "unique, not null"
     }
 
     IDP_IDENTITY {
         uint id PK
-        uint userid FK
-        string provider "Ex: google"
-        string subject
-        string refresh_token "(digest)"
-        datetime expiration
-        datetime last_authenticated
-        datetime last_refreshed
+        time create_time
+        string create_user
+        string update_user
+        string issuer "not null"
+        string subject "unique, not null"
+        string refresh_token "encrypted, not null"
+        time expiration "indexed"
+        time last_authenticated
+        time last_refreshed
+        string scopes
+        string roles
+        string userid
+        string email
     }
     
+    CLIENT {
+        uint id PK
+        time create_time
+        string create_user
+        string update_user
+        string auth_id "unique, not null"
+        string secret "not null"
+        string grant_kind
+        string scopes
+        int token_lifespan "not null"
+    }
     
+    RSA_KEY {
+        uint id PK
+        time create_time
+        string create_user
+        string update_user
+        string pem "not null, secret"
+    }
+    
+    GRANT {
+        uint id PK
+        time create_time
+        string create_user
+        string update_user
+        string kind "not null"
+        string auth_id "unique, not null"
+        string subject "indexed"
+        string refresh_token "unique, digest"
+        string auth_code "indexed"
+        string scopes
+        time issued
+        time expiration
+        uint client_id FK
+    }
     
     TOKEN {
         uint id PK
-        uint user_id FK
-        uint idp_identity_id FK "0 = none"
-        string jti "jwt id"
-        datetime expiration
+        time create_time
+        string create_user
+        string update_user
+        string kind "not null (JWT, PAT, etc)"
+        string auth_id "unique, not null"
+        string subject "indexed"
+        string digest "indexed"
+        string scopes "not null"
+        time issued "not null"
+        time expiration
+        time revoked
+        uint grant_id FK "nullable"
+        uint user_id FK "nullable"
+        uint idp_identity_id FK "nullable"
+        uint task_id FK "nullable"
     }
     
     TASK {
-    uint id PK
+        uint id PK
+        time create_time
+        string create_user
+        string update_user
     }
 ```
 
 ### Implementation Notes
 
-- The Token table contains hub-issued tokens only
-- The Token._expiration_ column is mainly used for reaping expired tokens
-- PATs are stored in the DB but cached in memory for performance and to mitigate DB pressure
+- The Token table is unified and contains all token types (JWTs, PATs, etc.) differentiated by the `kind` field
+- The Token.expiration column is mainly used for reaping expired tokens
+- The Token.digest column stores hashed tokens for lookup (PATs and refresh tokens)
+- The Grant table stores OIDC authorization grants, including authorization codes and refresh token metadata
+- Client registrations are stored in the Client table
+- RSA signing keys are stored in the RsaKey table
 
 ## Authentication Flows
 
@@ -430,8 +501,8 @@ token: cvP1sjff7_X2dCEIzUPf8f0IzKSbwiSDf1dZChZuRxY
 
 **Implementation details:**
 - PATs are 256-bit HEX strings.
-- The PAT is stored as a hashed digest in the database.
-- Permissions (scopes) are inherited from the user's role assignments.
+- PATs are stored in the Token table with `kind = "PAT"` as a hashed digest in the `digest` field.
+- Permissions (scopes) are inherited from the user's role assignments and stored in the `scopes` field.
 - PATs can have optional expiration dates.
 
 ### Authentication
@@ -443,9 +514,9 @@ Authorization: Bearer <token>
 
 **Validation process:**
 1. Extract the token from the Authorization header
-2. Hash and lookup the stored token in the database
-3. Verify the token is not expired or revoked
-4. Retrieve associated permissions (scopes)
+2. Hash and lookup the token in the Token table by digest
+3. Verify the token is not expired (check `expiration` field) or revoked (check `revoked` timestamp)
+4. Retrieve associated permissions from the `scopes` field
 5. Authorize endpoint access based on scopes
 
 ### Addon Tokens
@@ -526,12 +597,12 @@ groups:
 
 ## Token Revocation
 
-Tokens and PATs can be explicitly revoked:
+Tokens and grants can be explicitly revoked:
 
 - **DELETE /auth/grants/:id** - Revokes a specific OIDC grant (effective on next refresh)
-- **DELETE /auth/tokens/:id** - Revokes a specific PAT (effective immediately)
+- **DELETE /auth/tokens/:id** - Revokes a specific token (JWT, PAT, etc., effective immediately)
 
-Revocation is tracked in the database to ensure revoked credentials are not accepted.
+Revocation is tracked in the database via the Token.revoked timestamp field to ensure revoked credentials are not accepted.
 
 ## Configuration Management
 

--- a/enhancements/hub-oidc-provider/DESIGN.md
+++ b/enhancements/hub-oidc-provider/DESIGN.md
@@ -14,13 +14,13 @@ The Hub will function as an OIDC provider with the following components:
 
 ### Resource Management Endpoints
 
-| Method                | Path                 | Purpose                        |
-|-----------------------|----------------------|--------------------------------|
-| ANY                   | /auth/users          | User collection                |
-| ANY                   | /auth/roles          | Roles collection               |
-| GET                   | /auth/permissions    | Permission collection          |
-| POST \| GET \| DELETE | /auth/tokens         | Issued tokens                  |
-| GET                   | /auth/idp/identities | Remote IDP identity collection |
+| Method                | Path                 | Purpose                                                  |
+|-----------------------|----------------------|----------------------------------------------------------|
+| ANY                   | /auth/users          | User collection                                          |
+| ANY                   | /auth/roles          | Roles collection                                         |
+| GET                   | /auth/permissions    | Permission collection                                    |
+| POST \| GET \| DELETE | /auth/tokens         | PAT management (requires authentication)                 |
+| GET                   | /auth/idp/identities | Remote IDP identity collection                           |
 
 
 ### Standard OIDC Endpoints
@@ -482,28 +482,37 @@ sequenceDiagram
 
 ### Generation
 
-PATs are generated via POST to `/auth/tokens` and inherit permissions from the creating user's roles.
+PATs are generated via authenticated POST to `/auth/tokens`. The user must already be
+authenticated and present a valid access token (e.g., from OIDC login). The PAT inherits
+permissions from the authenticated user's roles.
 
 **Request:**
+```http
 POST /auth/tokens
-```yaml
-kind:       # (PAT|JWT)
-lifespan:   # OPTIONAL (hours)
-expiration: # OPTIONAL (datetime)
+Authorization: Bearer <access_token>
+Content-Type: application/json
+
+{
+  "lifespan": 720,     // OPTIONAL (hours)
+  "expiration": "..."  // OPTIONAL (datetime)
+}
 ```
 
 **Response:**
-```yaml
-id: 18
-expiration: # OPTIONAL
-token: cvP1sjff7_X2dCEIzUPf8f0IzKSbwiSDf1dZChZuRxY
+```json
+{
+  "id": 18,
+  "token": "cvP1sjff7_X2dCEIzUPf8f0IzKSbwiSDf1dZChZuRxY",
+  "expiration": "..."  // OPTIONAL
+}
 ```
 
 **Implementation details:**
-- PATs are 256-bit HEX strings.
-- PATs are stored in the Token table with `kind = "PAT"` as a hashed digest in the `digest` field.
-- Permissions (scopes) are inherited from the user's role assignments and stored in the `scopes` field.
-- PATs can have optional expiration dates.
+- Requires valid authentication - user must present an access token
+- PATs are 256-bit HEX strings
+- PATs are stored in the Token table with `kind = "PAT"` as a hashed digest in the `digest` field
+- Permissions (scopes) are inherited from the authenticated user's role assignments and stored in the `scopes` field
+- PATs can have optional expiration dates
 
 ### Authentication
 
@@ -521,9 +530,11 @@ Authorization: Bearer <token>
 
 ### Addon Tokens
 
-The task manager and addon API authorization will be refactored to use PATs instead of custom JWT token generation:
+The task manager and addon API authorization will be refactored to use PATs instead of custom JWT
+token generation:
 - New tasks will be configured with PATs for authentication
-- Legacy support: Tokens with `SigningMethod=HMAC` will still be honored for backwards compatibility with in-flight tasks
+- Legacy support: Tokens with `SigningMethod=HMAC` will still be honored for backwards
+  compatibility with in-flight tasks
 - This provides a unified authentication mechanism across all programmatic access
 
 ## LDAP/Active Directory Group Mapping
@@ -602,18 +613,24 @@ Tokens and grants can be explicitly revoked:
 - **DELETE /auth/grants/:id** - Revokes a specific OIDC grant (effective on next refresh)
 - **DELETE /auth/tokens/:id** - Revokes a specific token (JWT, PAT, etc., effective immediately)
 
-Revocation is tracked in the database via the Token.revoked timestamp field to ensure revoked credentials are not accepted.
+Revocation is tracked in the database via the Token.revoked timestamp field to ensure revoked
+credentials are not accepted.
 
 ## Configuration Management
 
 ### OIDC Configuration
 
-All OIDC-related configuration is loaded from a single Secret (`hub-oidc`) seeded by the operator. This Secret contains:
+All OIDC-related configuration is loaded from a single Secret (`hub-oidc`) seeded by the operator.
+This Secret contains:
 
-- **Client registrations** (`clients:` section): Registered OIDC clients (UI, CLI tools, etc.) with their credentials, redirect URIs, and allowed scopes
-- **External IdP configurations** (`idp:` section): External identity provider configurations (Keycloak, Google, LDAP, etc.) with connection details and credentials
+- **Client registrations** (`clients:` section): Registered OIDC clients (UI, CLI tools, etc.)
+  with their credentials, redirect URIs, and allowed scopes
+- **External IdP configurations** (`idp:` section): External identity provider configurations
+  (Keycloak, Google, LDAP, etc.) with connection details and credentials
 
-This unified approach allows the operator to manage all OIDC configuration atomically without requiring database access. The Secret is mounted into the Hub at `/etc/hub/` and read at startup (file: `/etc/hub/oidc.yaml`).
+This unified approach allows the operator to manage all OIDC configuration atomically without
+requiring database access. The Secret is mounted into the Hub at `/etc/hub/` and read at startup
+(file: `/etc/hub/oidc.yaml`).
 
 Example structure:
 ```yaml
@@ -648,4 +665,5 @@ The login page UI fragment is read from a ConfigMap managed by the operator. Thi
 
 ### Security
 
-All sensitive information is stored securely in the database: passwords as bcrypt hashes, refresh tokens encrypted. PATs are stored as cryptographic hashes (digests) only, never in plain text.
+All sensitive information is stored securely in the database: passwords as bcrypt hashes, refresh
+tokens encrypted. PATs are stored as cryptographic hashes (digests) only, never in plain text.

--- a/enhancements/hub-oidc-provider/DESIGN.md
+++ b/enhancements/hub-oidc-provider/DESIGN.md
@@ -62,7 +62,7 @@ erDiagram
     USER {
         uint id PK
         string userid "unique"
-        string password "encrypted"
+        string password "bcrypt hash"
         string email "unique"
     }
 
@@ -553,4 +553,4 @@ The login page UI fragment is read from a ConfigMap managed by the operator. Thi
 
 ### Security
 
-All sensitive information (passwords, refresh tokens) is stored encrypted in the database. API keys are stored as cryptographic hashes (digests) only, never in plain text.
+All sensitive information is stored securely in the database: passwords as bcrypt hashes, refresh tokens encrypted. API keys are stored as cryptographic hashes (digests) only, never in plain text.

--- a/enhancements/hub-oidc-provider/DESIGN.md
+++ b/enhancements/hub-oidc-provider/DESIGN.md
@@ -25,15 +25,17 @@ The Hub will function as an OIDC provider with the following components:
 
 ### Standard OIDC Endpoints
 
-| Method | Path                              | Purpose                                                                                        |
-|--------|-----------------------------------|------------------------------------------------------------------------------------------------|
-| GET    | /.well-known/openid-configuration | Discovery document – Tells clients all the endpoints, supported scopes, grant types, etc.      |
-| GET    | /oidc/authorize                   | Authorization Endpoint – Starts the login flow (shows login form or redirects to external IdP) |
-| POST   | /oidc/token                       | Token Endpoint – Exchanges authorization code for access_token + id_token + refresh_token      |
-| GET    | /oidc/jwks                        | JSON Web Key Set – Public keys used by clients to verify your JWT signatures                   |
-| GET    | /oidc/userinfo                    | UserInfo Endpoint – Returns user claims (optional, but commonly used)                          |
-| POST   | /oidc/introspect                  | Token Introspection – Allows resource servers to validate opaque tokens (optional)             |
-| POST   | /oidc/revoke                      | Token Revocation – Allows clients to revoke refresh tokens (optional but recommended)          |
+| Method      | Path                              | Purpose                                                                                        |
+|-------------|-----------------------------------|------------------------------------------------------------------------------------------------|
+| GET         | /.well-known/openid-configuration | Discovery document – Tells clients all the endpoints, supported scopes, grant types, etc.      |
+| GET         | /oidc/authorize                   | Authorization Endpoint – Starts the login flow (shows login form or redirects to external IdP) |
+| POST        | /oidc/token                       | Token Endpoint – Exchanges authorization code for access_token + id_token + refresh_token      |
+| GET         | /oidc/jwks                        | JSON Web Key Set – Public keys used by clients to verify your JWT signatures                   |
+| GET         | /oidc/userinfo                    | UserInfo Endpoint – Returns user claims (optional, but commonly used)                          |
+| POST        | /oidc/introspect                  | Token Introspection – Allows resource servers to validate opaque tokens (optional)             |
+| POST        | /oidc/revoke                      | Token Revocation – Allows clients to revoke refresh tokens (optional but recommended)          |
+| POST        | /oidc/device/code                 | Device Authorization – Initiates device flow for CLI tools (returns user_code and device_code) |
+| GET \| POST | /oidc/device                      | Device Verification – User enters code to authorize device (part of device flow)               |
 
 ## Data Model
 
@@ -137,6 +139,9 @@ erDiagram
         string subject "indexed"
         string refresh_token "unique, digest"
         string auth_code "indexed"
+        string device_code "indexed"
+        string user_code "indexed"
+        string status "pending, authorized, denied"
         string scopes
         time issued
         time expiration
@@ -175,7 +180,9 @@ erDiagram
 - The Token table is unified and contains all token types (JWTs, PATs, etc.) differentiated by the `kind` field
 - The Token.expiration column is mainly used for reaping expired tokens
 - The Token.digest column stores hashed tokens for lookup (PATs and refresh tokens)
-- The Grant table stores OIDC authorization grants, including authorization codes and refresh token metadata
+- The Grant table stores OIDC authorization grants, including authorization codes, device codes, and refresh token metadata
+- Grant.kind values include: "authorization_code", "device_code", "refresh_token"
+- Grant.status tracks device authorization state: "pending", "authorized", "denied"
 - Client registrations are stored in the Client table
 - RSA signing keys are stored in the RsaKey table
 
@@ -372,6 +379,106 @@ sequenceDiagram
 
     deactivate ProtectedAPI
 ```
+
+### Device Authorization Grant (DAC) Flow
+
+The Device Authorization Grant flow (RFC 8628) enables authentication for CLI tools and devices with limited input capabilities:
+
+```mermaid
+sequenceDiagram
+    participant CLI as CLI Tool
+    participant Hub as Hub Provider<br>(OIDC Provider)
+    participant User as User<br>(Browser)
+    participant DB as Database
+
+    Note over CLI,Hub: Device Authorization Flow for CLI Tools
+
+    %% === Device Code Request ===
+    CLI->>Hub: POST /oidc/device/code<br>client_id=cli&scope=openid profile email
+    activate Hub
+    
+    Hub->>Hub: Generate device_code + user_code
+    Hub->>DB: Store device authorization grant (pending)
+    
+    Hub-->>CLI: device_code, user_code, verification_uri<br>expires_in, interval
+    deactivate Hub
+
+    Note over CLI: Display to user:<br>"Visit https://hub.example.com/oidc/device<br>and enter code: ABCD-EFGH"
+
+    %% === User Authorization ===
+    User->>Hub: GET /oidc/device (verification_uri)
+    activate Hub
+    Hub-->>User: Show code entry form
+    deactivate Hub
+
+    User->>Hub: POST /oidc/device<br>user_code=ABCD-EFGH
+    activate Hub
+    
+    Hub->>DB: Lookup device grant by user_code
+    
+    alt Invalid or expired user_code
+        Hub-->>User: Error: Invalid code
+    else Valid user_code
+        alt User not authenticated
+            Hub-->>User: Redirect to login page
+            User->>Hub: Authenticate (username + password or external IdP)
+            Hub->>DB: Verify credentials / fetch user + roles
+        else User already authenticated
+            Note right of Hub: User has active session
+        end
+        
+        Hub-->>User: Show authorization prompt<br>"CLI tool wants to access your account"
+        
+        User->>Hub: Approve authorization
+        
+        Hub->>DB: Mark device grant as authorized<br>store subject + scopes
+        Hub-->>User: Success: "You can close this window"
+    end
+    deactivate Hub
+
+    %% === Token Polling ===
+    Note over CLI,Hub: CLI polls for token (every interval seconds)
+
+    loop Polling until authorized or timeout
+        CLI->>Hub: POST /oidc/token<br>grant_type=urn:ietf:params:oauth:grant-type:device_code<br>device_code=...&client_id=cli
+        activate Hub
+        
+        Hub->>DB: Lookup device grant by device_code
+        
+        alt Grant not yet authorized
+            Hub-->>CLI: 400 authorization_pending<br>(keep polling)
+        else Grant denied
+            Hub-->>CLI: 403 access_denied
+        else Grant expired
+            Hub-->>CLI: 400 expired_token
+        else Grant authorized
+            Hub->>Hub: Generate tokens with user scopes/roles
+            Hub->>DB: Create token records + update grant
+            Hub-->>CLI: Access Token + ID Token + Refresh Token
+            Note over CLI: Authentication complete!
+        end
+        
+        deactivate Hub
+        
+        CLI->>CLI: Wait interval seconds before next poll
+    end
+
+    Note over CLI: Store tokens for API access<br>Use refresh_token for token renewal
+```
+
+**Key endpoints:**
+- **POST /oidc/device/code** - Initiate device flow, returns user_code and device_code
+- **GET /oidc/device** - User verification page (displays code entry form)
+- **POST /oidc/device** - User submits user_code for authorization
+- **POST /oidc/token** - CLI polls for token using grant_type=urn:ietf:params:oauth:grant-type:device_code
+
+**Implementation notes:**
+- User codes should be short and human-friendly (e.g., "ABCD-EFGH", 8 characters)
+- Device codes are long, random strings for security
+- Default expiration: 900 seconds (15 minutes)
+- Default polling interval: 5 seconds
+- Clients should implement exponential backoff if Hub returns `slow_down` error
+- Device grants are single-use and must be deleted after token issuance or expiration
 
 ## Token Validation
 
@@ -702,12 +809,24 @@ stringData:
 | response_type | code                                |
 | usePKCE       | true                                |
 
-**CLI (binding):**
+**CLI (Device Authorization Grant):**
 
-| setting   | value                    |
-|-----------|--------------------------|
-| issuerURL | hub-service-address/oidc |
-| clientID  | cli                      |
+| setting         | value                                               |
+|-----------------|-----------------------------------------------------|
+| issuerURL       | hub-service-address/oidc                            |
+| clientID        | cli                                                 |
+| grant_type      | urn:ietf:params:oauth:grant-type:device_code        |
+| scope           | openid profile email offline_access                 |
+| device_endpoint | hub-service-address/oidc/device/code                |
+| token_endpoint  | hub-service-address/oidc/token                      |
+
+**Device flow behavior:**
+- CLI initiates flow by requesting device_code and user_code
+- User opens verification_uri in browser and enters user_code
+- CLI polls token endpoint every 5 seconds (default interval)
+- Once user authorizes, CLI receives tokens
+- No client_secret required (public client)
+- Supports PKCE for additional security (optional but recommended)
 
 
 ### Login UI

--- a/enhancements/hub-oidc-provider/DESIGN.md
+++ b/enhancements/hub-oidc-provider/DESIGN.md
@@ -7,21 +7,20 @@ This document contains the detailed design specifications for the builtin Auth e
 The Hub will function as an OIDC provider with the following components:
 - User and role-based access control (RBAC) managed in the Hub inventory
 - Support for local authentication or delegation to external providers (OIDC, LDAP/Active Directory)
-- API key-based authentication for programmatic access
+- Personal Access Token (PAT) based authentication for programmatic access
 - Token issuance, validation, and revocation
 
 ## Routes and Endpoints
 
 ### Resource Management Endpoints
 
-| Method        | Path                 | Purpose                        |
-|---------------|----------------------|--------------------------------|
-| ANY           | /auth/users          | User collection                |
-| ANY           | /auth/roles          | Roles collection               |
-| GET           | /auth/permissions    | Permission collection          |
-| GET \| DELETE | /auth/tokens         | Issued tokens                  |
-| ANY           | /auth/apikeys        | API-Key collection             |
-| GET           | /auth/idp/identities | Remote IDP identity collection |
+| Method                | Path                 | Purpose                        |
+|-----------------------|----------------------|--------------------------------|
+| ANY                   | /auth/users          | User collection                |
+| ANY                   | /auth/roles          | Roles collection               |
+| GET                   | /auth/permissions    | Permission collection          |
+| POST \| GET \| DELETE | /auth/tokens         | Issued tokens                  |
+| GET                   | /auth/idp/identities | Remote IDP identity collection |
 
 
 ### Standard OIDC Endpoints
@@ -46,7 +45,7 @@ The Hub will function as an OIDC provider with the following components:
 - **Permission** - Named permissions mapped to scopes
 - **IdpIdentity** - Identities authenticated by remote IdP provider. Contains the refresh token.
 - **Token** - Issued (valid) tokens
-- **APIKey** - Issued (valid) API-Keys
+- **PAT** - Issued (valid) Personal Access Tokens
 
 ### Entity Relationship Diagram
 
@@ -54,8 +53,8 @@ The Hub will function as an OIDC provider with the following components:
 erDiagram
     USER }o--o{ ROLE : "granted"
     ROLE }o--o{ PERMISSION : "has"
-    USER ||--o{ API_KEY : "owns"
-    TASK ||--o{ API_KEY : "owns"
+    USER ||--o{ PAT : "owns"
+    TASK ||--o{ PAT : "owns"
     IDP_IDENTITY ||--|| USER : "EXTERNAL identity"
     IDP_IDENTITY ||--|| TOKEN : "delegated authentication"
 
@@ -77,24 +76,18 @@ erDiagram
         string scope "scope"
     }
 
-    API_KEY {
-        uint id PK
-        uint user_id FK
-        uint task_id FK
-        string digest "unique, hashed-secret"
-        datetime expiration
-    }
-
     IDP_IDENTITY {
         uint id PK
-        uint user_id FK
+        uint userid FK
         string provider "Ex: google"
         string subject
-        string refresh_token "(encrypted)"
+        string refresh_token "(digest)"
         datetime expiration
         datetime last_authenticated
         datetime last_refreshed
     }
+    
+    
     
     TOKEN {
         uint id PK
@@ -113,7 +106,7 @@ erDiagram
 
 - The Token table contains hub-issued tokens only
 - The Token._expiration_ column is mainly used for reaping expired tokens
-- API-Keys are stored in the DB but cached in memory for performance and to mitigate DB pressure
+- PATs are stored in the DB but cached in memory for performance and to mitigate DB pressure
 
 ## Authentication Flows
 
@@ -322,7 +315,7 @@ sequenceDiagram
     participant Hub as Hub Provider<br>(OIDC Provider)
     participant DB as API Key Database / Store
 
-    Note over UI,ProtectedAPI: Bearer Token Validation Flow<br>(JWT RSA + JWT HMAC deprecated + API Keys)
+    Note over UI,ProtectedAPI: Bearer Token Validation Flow<br>(JWT RSA + JWT HMAC deprecated + PATs)
 
     UI->>ProtectedAPI: GET /api/projects<br>Authorization: Bearer <token>
     activate ProtectedAPI
@@ -346,15 +339,15 @@ sequenceDiagram
         ProtectedAPI->>ProtectedAPI: 4. Validate Standard JWT Claims (iss, aud, exp, etc.)
         ProtectedAPI->>ProtectedAPI: 5. Extract Claims (sub, scope, roles...)
 
-    else Token is NOT a valid JWT → Treat as API Key
-        ProtectedAPI->>DB: 2b. Lookup API Key in DB
+    else Token is NOT a valid JWT → Treat as PAT
+        ProtectedAPI->>DB: 2b. Lookup PAT in DB
         activate DB
-        DB-->>ProtectedAPI: Key record (active?, scopes/permissions)
+        DB-->>ProtectedAPI: PAT record (active?, scopes/permissions)
         deactivate DB
 
-        alt API Key invalid or revoked
+        alt PAT invalid or revoked
             ProtectedAPI-->>UI: 401 Unauthorized
-        else API Key valid
+        else PAT valid
             ProtectedAPI->>ProtectedAPI: 3c. Map DB permissions to scopes
         end
     end
@@ -372,7 +365,7 @@ sequenceDiagram
 
     deactivate ProtectedAPI
 
-    Note over ProtectedAPI: Key Notes<br/>RSA via JWKS is strongly preferred.<br/>HMAC is deprecated but honored for backwards compatibility.<br/>API Keys are mapped to the same scope model as JWTs.<br/>Always reject alg="none" and unknown algorithms.<br/>Consider logging HMAC usage for migration tracking.
+    Note over ProtectedAPI: Key Notes<br/>RSA via JWKS is strongly preferred.<br/>HMAC is deprecated but honored for backwards compatibility.<br/>PATs are mapped to the same scope model as JWTs.<br/>Always reject alg="none" and unknown algorithms.<br/>Consider logging HMAC usage for migration tracking.
 ```
 
 ### External IdP Token Validation
@@ -414,16 +407,17 @@ sequenceDiagram
     deactivate ProtectedAPI
 ```
 
-## API Key Authentication
+## Personal Access Token (PAT) Authentication
 
 ### Generation
 
-API keys are generated via POST to `/auth/apikey` and inherit permissions from the creating user's roles.
+PATs are generated via POST to `/auth/tokens` and inherit permissions from the creating user's roles.
 
 **Request:**
+POST /auth/tokens
 ```yaml
-POST /auth/apikey
-
+kind:       # (PAT|JWT)
+lifespan:   # OPTIONAL (hours)
 expiration: # OPTIONAL (datetime)
 ```
 
@@ -431,33 +425,33 @@ expiration: # OPTIONAL (datetime)
 ```yaml
 id: 18
 expiration: # OPTIONAL
-key: cvP1sjff7_X2dCEIzUPf8f0IzKSbwiSDf1dZChZuRxY
+token: cvP1sjff7_X2dCEIzUPf8f0IzKSbwiSDf1dZChZuRxY
 ```
 
 **Implementation details:**
-- Keys are 256-bit base64URL-encoded strings
-- The key is stored as a hashed digest in the database
-- Permissions (scopes) are inherited from the user's role assignments at creation time
-- Keys can have optional expiration dates
+- PATs are 256-bit HEX strings.
+- The PAT is stored as a hashed digest in the database.
+- Permissions (scopes) are inherited from the user's role assignments.
+- PATs can have optional expiration dates.
 
 ### Authentication
 
-API keys are presented as Bearer tokens:
+PATs are presented as Bearer tokens:
 ```
-Authorization: Bearer <key>
+Authorization: Bearer <token>
 ```
 
 **Validation process:**
-1. Extract the key from the Authorization header
-2. Hash and lookup the stored key in the database
-3. Verify the key is not expired or revoked
+1. Extract the token from the Authorization header
+2. Hash and lookup the stored token in the database
+3. Verify the token is not expired or revoked
 4. Retrieve associated permissions (scopes)
 5. Authorize endpoint access based on scopes
 
 ### Addon Tokens
 
-The task manager and addon API authorization will be refactored to use API keys instead of custom JWT token generation:
-- New tasks will be configured with API keys for authentication
+The task manager and addon API authorization will be refactored to use PATs instead of custom JWT token generation:
+- New tasks will be configured with PATs for authentication
 - Legacy support: Tokens with `SigningMethod=HMAC` will still be honored for backwards compatibility with in-flight tasks
 - This provides a unified authentication mechanism across all programmatic access
 
@@ -465,7 +459,8 @@ The task manager and addon API authorization will be refactored to use API keys 
 
 ### Policy Schema
 
-The group-to-role mapping policy is expressed in YAML and can be managed through the UI. The policy defines how LDAP/AD group memberships map to internal roles.
+The group-to-role mapping policy is expressed in YAML and can be managed through the UI. The policy defines how LDAP/AD 
+group memberships map to internal roles.
 
 **Structure:**
 - Each mapping rule contains a conditional expression (`any` or `and`) and a list of `roles` to assign
@@ -531,10 +526,10 @@ groups:
 
 ## Token Revocation
 
-Tokens and API keys can be explicitly revoked:
+Tokens and PATs can be explicitly revoked:
 
-- **DELETE /auth/tokens/:id** - Revokes a specific token (effective on next refresh)
-- **DELETE /auth/apikeys/:id** - Revokes a specific API key (effective immediately)
+- **DELETE /auth/grants/:id** - Revokes a specific OIDC grant (effective on next refresh)
+- **DELETE /auth/tokens/:id** - Revokes a specific PAT (effective immediately)
 
 Revocation is tracked in the database to ensure revoked credentials are not accepted.
 
@@ -553,4 +548,4 @@ The login page UI fragment is read from a ConfigMap managed by the operator. Thi
 
 ### Security
 
-All sensitive information is stored securely in the database: passwords as bcrypt hashes, refresh tokens encrypted. API keys are stored as cryptographic hashes (digests) only, never in plain text.
+All sensitive information is stored securely in the database: passwords as bcrypt hashes, refresh tokens encrypted. PATs are stored as cryptographic hashes (digests) only, never in plain text.

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -83,12 +83,18 @@ Access tokens may be revoked (effective next refresh).
 Add support for API-Keys (Reference [RFE-266](https://github.com/konveyor/enhancements/issues/266)).
 
 #### Generation
-POST /auth/apikey returns a 256-bit base64-encoded generated key which has been stored in the DB along with associated
-permissions (scopes).
+
+POST /auth/apikey returns a 256-bit base64URL-encoded generated key which has been stored in the DB along 
+with associated permissions (scopes).
+Body:
+```yaml
+expiration: # OPTIONAL
+```
 Returned:
 ```yaml
 id: uint
-key: base64-encoded key. (This is the key presented to the API).
+expiration: # OPTIONAL
+key: cvP1sjff7_X2dCEIzUPf8f0IzKSbwiSDf1dZChZuRxY # base64URL-encoded key. (This is the key presented to the API).
 ```
 
 #### Revocation

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -40,14 +40,11 @@ Eliminate dependence on Keycloak.
 ### Goals
 
 - **To discontinue dependence on keycloak**.
-- To provide AuthZ _out-of-the-box_.
-- To (optionally) delegate authentication to an external OIDC provider
-- To (optionally) delegate authorization to an external OIDC provider.
 - To discontinue seeding the realm in keycloak.
-- To support user management in the tackle UI.
-  - User CRUD.
-  - Role CRUD with association scopes.
-  - Grant roles to users.
+- To provide OIDC-based Auth _out-of-the-box_.
+- To delegate AuthN, AuthZ to an _external_ OIDC provider. (option)
+- To delegate AuthN, AuthZ to an _external_ LDAP, Active Directory with group mapping. (option)
+- To provide RBAC (users, roles, permissions) management in the inventory.
 
 ### Non-Goals
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -169,7 +169,7 @@ erDiagram
     API_KEY {
         uint id PK
         uint user_id FK
-        string key "unique"
+        string key "unique (encrypted)"
         datetime expiration
     }
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -58,6 +58,16 @@ to delegate authentication and/or authorization to an external provider. The hub
 is augmented to include Users and Roles. Users may be associated to roles and roles may
 be associated to permissions (scopes).
 
+The UI will be updated to use OIDC (instead of keycloak) and be configured to use the
+hub OIDC provider.  The UI will have pages to manage user, roles and permissions.
+
+### Security, Risks, and Mitigations
+
+The [go-oidc](https://github.com/luikyv/go-oidc) package is **OpenID certified** and is actively maintained. It has no reported CVEs.  AI code analysis
+reports no vulnerabilities or backdoors.
+
+## Design Details
+
 High Level Model:
 
 ```mermaid
@@ -287,16 +297,6 @@ sequenceDiagram
 
     deactivate ProtectedAPI
 ```
-
-The UI will be updated to use OIDC (instead of keycloak) and be configured to use the
-hub OIDC provider.  The UI will have pages to manage user, roles and permissions.
-
-### Security, Risks, and Mitigations
-
-The [go-oidc](https://github.com/luikyv/go-oidc) package is **OpenID certified** and is actively maintained. It has no reported CVEs.  AI code analysis
-reports no vulnerabilities or backdoors.
-
-## Design Details
 
 ### Test Plan
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -147,12 +147,13 @@ erDiagram
     USER }o--o{ ROLE : "granted"
     ROLE }o--o{ PERMISSION : "has"
     USER ||--o{ API_KEY : "owns"
+    TASK ||--0{ API_KEY : "owns"
     IDP_IDENTITY ||--|| USER : "EXTERNAL identity"
     IDP_IDENTITY ||--|| TOKEN : "delegated authentication"
 
     USER {
         uint id PK
-        string username "unique"
+        string userid "unique"
         string password "encrypted"
         string email "unique"
     }
@@ -171,7 +172,8 @@ erDiagram
     API_KEY {
         uint id PK
         uint user_id FK
-        string digest "unique"
+        uint task_id FK
+        string digest "unique, hashed-secret"
         datetime expiration
     }
 
@@ -195,6 +197,10 @@ erDiagram
         datetime revoked "nullable"
         datetime last_authenticated
         datetime last_refreshed
+    }
+    
+    TASK {
+    uint id PK
     }
 ```
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -53,7 +53,7 @@ Eliminate dependence on Keycloak.
 
 ## Proposal
 
-Make the hub an OIDC provider. The provider policy may be self-contained or configured
+Make the hub an OIDC provider. The security policy may be self-contained or configured
 to delegate authentication and/or authorization to an external provider. The hub inventory
 is augmented to include Users and Roles. Users may be associated to roles and roles may
 be associated to permissions (scopes).

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -162,8 +162,8 @@ complex authorization requirements.
 #### Personal Access Token (PAT) Authentication
 
 PATs provide a secure mechanism for programmatic access, addressing
-[RFE-266](https://github.com/konveyor/enhancements/issues/266). Users can
-generate PATs through the Hub API, which inherit the user's permissions at
+[RFE-266](https://github.com/konveyor/enhancements/issues/266). Authenticated users can
+generate PATs through the Hub API (`POST /auth/tokens`), which inherit the user's permissions at
 the time of creation. PATs are presented as Bearer tokens and validated using
 the same scope-based authorization model as JWT tokens.
 
@@ -178,11 +178,45 @@ expose PATs.
 
 #### Tools Integration
 
-Client tools such as **Kantra** and **KAI** should authenticate by getting an
-PAT.  This is almost exactly like the current process of getting a (JWT)
-token (POST `/auth/token`), the client will POST to a new endpoint that instead
-returns a PAT. The returned token is specified in future requests using
-authentication header: `Authorization Bearer <token>`.
+##### CLI Tools (Kantra)
+
+**Kantra**, as a command-line tool, cannot display web pages for interactive OIDC login flows.
+Authentication options include:
+
+1. **Manual PAT configuration**: Users obtain a PAT through the Hub UI and provide it to Kantra
+   via command line option (e.g., `--token`) or environment variable (e.g., `TOKEN`)
+2. **Device code flow**: Kantra initiates an OIDC device authorization flow, displays a code and
+   URL for the user to visit in a browser, completes authentication, then optionally requests a
+   PAT for long-lived access
+
+The previous method of POSTing username/password directly to obtain a token is no longer
+supported. This approach relied on the OAuth 2.0 Resource Owner Password Credentials (Direct
+Access) grant type, which was deprecated in OAuth 2.1 due to security concerns. The Direct
+Access grant exposes user credentials to client applications and bypasses modern security
+measures like multi-factor authentication and federated identity providers.
+
+##### IDE Plugin (KAI)
+
+**KAI**, as a VS Code extension, has more flexibility since it can display web content within
+the IDE. It supports two authentication modes:
+
+1. **Manual PAT configuration**: Users obtain a PAT through the Hub UI and configure KAI with it
+   in the extension settings. This is the simplest approach for users who prefer manual
+   credential management.
+
+2. **Interactive OIDC flow**: KAI can display the Hub login page in a VS Code webview, allowing
+   users to complete the OIDC authentication flow directly within the IDE:
+   - KAI initiates the OIDC authorization code flow
+   - Displays the Hub login page in a webview
+   - User authenticates (local credentials or external IdP)
+   - KAI receives the access token via redirect
+   - KAI can then request a PAT via `POST /auth/tokens` for use by AI agents
+
+The ability to obtain a PAT after OIDC login is particularly useful for KAI's AI agents, which
+run in the background and need long-lived credentials. PATs allow these agents to continue
+working without requiring interactive re-authentication.
+
+##### LLM Proxy
 
 The **LLM Proxy** will no longer perform token authentication. Instead, the LLM Proxy servers
 will be proxied behind the hub /services endpoint and delegate auth to the hub.
@@ -264,8 +298,10 @@ The operator will require significant changes to support the Hub's built-in OIDC
 
 #### Hub Configuration
 
-- **Replace Keycloak configuration**: The operator will remove Keycloak-specific configuration from the Hub deployment and replace it with OIDC provider configuration settings
-- **OIDC key signing secret**: The operator must create and manage a Kubernetes Secret containing the RSA private key used by the Hub to sign JWT tokens. This secret will be:
+- **Replace Keycloak configuration**: The operator will remove Keycloak-specific configuration
+  from the Hub deployment and replace it with OIDC provider configuration settings
+- **OIDC key signing secret**: The operator must create and manage a Kubernetes Secret containing
+  the RSA private key used by the Hub to sign JWT tokens. This secret will be:
   - Generated automatically during initial deployment
   - Mounted into the Hub pod
   - Rotatable through operator-managed updates
@@ -274,9 +310,11 @@ The operator will require significant changes to support the Hub's built-in OIDC
 
 #### UI Configuration
 
-The UI deployment will be configured to authenticate against the Hub's OIDC provider instead of Keycloak:
+The UI deployment will be configured to authenticate against the Hub's OIDC provider instead of
+Keycloak:
 
-- **OIDC client registration**: The operator will configure the UI with OIDC client credentials via ConfigMap or environment variables:
+- **OIDC client registration**: The operator will configure the UI with OIDC client credentials
+  via ConfigMap or environment variables:
   - `OIDC_ISSUER`: Points to the Hub's OIDC endpoint (e.g., `https://hub.konveyor.io`)
   - `OIDC_CLIENT_ID`: Unique identifier for the UI client (e.g., `konveyor-ui`)
   - `OIDC_CLIENT_SECRET`: Client secret for confidential client authentication (stored in a Secret)
@@ -285,9 +323,12 @@ The UI deployment will be configured to authenticate against the Hub's OIDC prov
 
 #### OIDC Configuration Secret
 
-- The operator will seed the Hub with all OIDC-related configuration via a single Secret (`hub-oidc`):
-  - **Client registrations**: UI client, CLI tool clients, etc. with their credentials and allowed scopes
-  - **External IdP configurations**: Keycloak, Google, LDAP, etc. with connection details and credentials
+- The operator will seed the Hub with all OIDC-related configuration via a single Secret
+  (`hub-oidc`):
+  - **Client registrations**: UI client, CLI tool clients, etc. with their credentials and
+    allowed scopes
+  - **External IdP configurations**: Keycloak, Google, LDAP, etc. with connection details and
+    credentials
   - This Secret will be mounted into the Hub at `/etc/hub/` and read at startup
 
 #### Migration Support

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -92,7 +92,7 @@ expiration: # OPTIONAL
 ```
 Returned:
 ```yaml
-id: uint
+id: 18
 expiration: # OPTIONAL
 key: cvP1sjff7_X2dCEIzUPf8f0IzKSbwiSDf1dZChZuRxY
 ```

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -78,6 +78,7 @@ High Level Model:
 erDiagram
     USER }o--o{ ROLE : "granted"
     ROLE }o--o{ PERMISSION : "has"
+    TOKEN ||--|| USER : "mapped"
 
     USER {
         uint id PK
@@ -95,6 +96,14 @@ erDiagram
         uint id PK
         string name "human readable name"
         string scope "OIDC scope"
+    }
+    
+    TOKEN {
+        uint id PK
+        uint user_id FK
+        datetime expiration
+        string provider "builtin|google|..."
+        string token "refresh token (encrypted)"
     }
 ```
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -319,7 +319,7 @@ Keycloak:
   - `OIDC_CLIENT_ID`: Unique identifier for the UI client (e.g., `konveyor-ui`)
   - `OIDC_CLIENT_SECRET`: Client secret for confidential client authentication (stored in a Secret)
   - `OIDC_REDIRECT_URI`: Callback URL for the authorization code flow (e.g., `https://ui.konveyor.io/auth/callback`)
-  - `OIDC_SCOPES`: Requested scopes (e.g., `openid profile email`)
+  - `OIDC_SCOPES`: Requested scopes (e.g., `openid profile email offline_access`)
 
 #### OIDC Configuration Secret
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -1,0 +1,279 @@
+---
+title: neat-enhancement-idea
+authors:
+  - "@janedoe"
+reviewers:
+  - TBD
+  - "@alicedoe"
+approvers:
+  - TBD
+  - "@oscardoe"
+creation-date: yyyy-mm-dd
+last-updated: yyyy-mm-dd
+status: provisional|implementable|implemented|deferred|rejected|withdrawn|replaced
+see-also:
+  - "/enhancements/this-other-neat-thing.md"  
+replaces:
+  - "/enhancements/that-less-than-great-idea.md"
+superseded-by:
+  - "/enhancements/our-past-effort.md"
+---
+
+# Builtin AuthZ
+
+Add builtin AuthZ functionality so that KeyCloak is no longer required.
+
+
+## Release Signoff Checklist
+
+- [ ] Enhancement is `implementable`
+- [ ] Design details are appropriately documented from clear requirements
+- [ ] Test plan is defined
+- [ ] User-facing documentation is created
+
+## Open Questions
+
+## Summary
+
+Currently, keycloak is required to provide user authentication and authorization. Both the Hub
+and the UI integrate with Keycloak using keycloak clients. The goal convert to OIDC (OpenID)
+for AuthZ integration and remove the dependence on keycloak.  Further, to provide an
+internal OIDC provider with optional delegation to an external OIDC provider (such as Keycloak
+but can be anything).
+
+## Motivation
+
+Eliminate dependence on Keycloak.
+
+### Goals
+
+- To provide AuthZ _out-of-the-box_.
+- To (optionally) delegate authentication to an external OIDC provider
+- To (optionally) delegate authorization to an external OIDC provider.
+- To discontinue dependence on keycloak.
+- To discontinue seeding the realm in keycloak.
+- To support user management in the tackle UI.
+  - User CRUD.
+  - Role CRUD
+  - User role assignment.
+
+### Non-Goals
+
+## Proposal
+
+Make the hub an OIDC provider. The provider policy may be self-contained or configured
+to delegate authentication and/or authorization to an external provider. Th hub inventory
+is augmented to include Users and Roles. Users may be associated to roles and roles may
+be associated to permissions (scopes).  Tokens will continue to contain scope claims.
+
+```mermaid
+sequenceDiagram
+    participant UI as UI (Client Application)
+    participant Hub as Hub Provider<br>(OIDC Provider)
+    participant User as User
+    participant DB as Database<br>(Users + Roles)
+
+    Note over UI,Hub: Authorization Code Flow with Local Authentication
+
+    UI->>Hub: GET /oauth2/authorize<br>?client_id=...&scope=openid profile email
+    activate Hub
+
+    Hub->>User: Redirect to Login Page
+    User->>Hub: Shows Login Form
+
+    User->>Hub: POST login credentials<br>(username + password)
+    activate Hub
+
+    Hub->>DB: Authenticate User<br>(check username + password)
+    DB-->>Hub: User record + associated Roles
+
+    Hub->>Hub: Validate Credentials
+
+    alt Invalid Credentials
+        Hub->>User: Show Login Page with Error
+        deactivate Hub
+    else Valid Credentials
+        Hub->>Hub: Set Subject (username)
+
+        Hub->>DB: Get User Roles & Scopes
+        DB-->>Hub: List of scopes from roles
+
+        Hub->>Hub: Apply Authorization Layer<br>(merge requested scopes + role-based scopes)
+
+        alt Consent Required
+            Hub->>User: Show Consent Screen<br>("Allow this app to access ...")
+            User->>Hub: User clicks Approve (or Deny)
+            
+            alt User Denies
+                Hub-->>UI: Redirect with error=access_denied
+            else User Approves
+                Hub->>DB: Save Consent (user + client)
+            end
+        else Consent Already Given
+            Note right of Hub: Skip consent screen
+        end
+
+        Hub-->>UI: Redirect back with authorization code
+        deactivate Hub
+    end
+
+    Note over UI,Hub: Back-channel token exchange
+
+    UI->>Hub: POST /oauth2/token<br>grant_type=authorization_code + code_verifier
+    activate Hub
+
+    Hub-->>UI: Access Token + ID Token + Refresh Token<br>(signed by Hub keys, containing role-based scopes)
+
+    deactivate Hub
+
+    Note over UI: UI now has tokens issued by Hub Provider<br>with local user identity + authorization from roles
+```
+
+When and external provider is configured, the login page rendered by the hub will contain a
+button for this.  For example: "Login with Google".
+
+```mermaid
+sequenceDiagram
+    participant UI as UI (Client Application)
+    participant Hub as Hub Provider<br>(OIDC Broker)
+    participant ExternalIdP as External IdP<br>(e.g. Google)
+    participant User as User
+    participant DB as Database<br>(Users + Roles)
+
+    Note over UI,Hub: Authorization Code Flow starts
+
+    UI->>Hub: GET /oauth2/authorize<br>?client_id=...&scope=...&idp=google
+    activate Hub
+
+    Hub->>User: Redirect to External Login<br>(or show IdP selector)
+    User->>ExternalIdP: Browser redirects to Google login page
+    activate ExternalIdP
+
+    ExternalIdP->>User: Show Google login / consent screen
+    User->>ExternalIdP: Authenticates (username/password or SSO)
+
+    ExternalIdP-->>User: Redirect back to Hub Provider<br>with authorization code
+    deactivate ExternalIdP
+
+    User->>Hub: Callback with code<br>(/oauth2/authorize/{callback_id}?code=...)
+
+    Hub->>ExternalIdP: POST /token (exchange code)
+    activate ExternalIdP
+    ExternalIdP-->>Hub: ID Token + Access Token
+    deactivate ExternalIdP
+
+    Hub->>ExternalIdP: GET UserInfo (optional)
+    ExternalIdP-->>Hub: User claims (sub, email, name, ...)
+
+    Hub->>DB: Lookup or Create User<br>(map Google sub/email → local user)
+    activate DB
+    DB-->>Hub: Local user record + associated Roles
+
+    Hub->>Hub: Apply Authorization Layer<br>(add role-based scopes, custom claims)
+    deactivate DB
+
+    alt Consent Required
+        Hub->>User: Show Consent Screen<br>("Allow this app to access ...")
+        User->>Hub: User approves (or denies)
+    else Consent Already Given
+        Note right of Hub: Skip consent
+    end
+
+    Hub-->>UI: Redirect back with authorization code
+    deactivate Hub
+
+    Note over UI,Hub: Back-channel token exchange
+
+    UI->>Hub: POST /oauth2/token<br>grant_type=authorization_code + code_verifier
+    activate Hub
+
+    Hub-->>UI: Access Token + ID Token + Refresh Token<br>(signed by Hub keys, with local scopes/claims)
+
+    deactivate Hub
+
+    Note over UI: UI now has tokens issued by the Hub Provider<br>containing both external identity + local authorization (roles/scopes)
+```
+
+The UI will be updated to use OIDC (instead of keycloak) and be configured to use the
+hub OIDC provider.  The UI will have pages to manage user, roles and permissions.
+
+### User Stories [optional]
+
+Detail the things that people will be able to do if this is implemented.
+Include as much detail as possible so that people can understand the "how" of
+the system. The goal here is to make this feel real for users without getting
+bogged down.
+
+#### Story 1
+
+#### Story 2
+
+### Implementation Details/Notes/Constraints [optional]
+
+What are the caveats to the implementation? What are some important details that
+didn't come across above. Go in to as much detail as necessary here. This might
+be a good place to talk about core concepts and how they relate.
+
+### Security, Risks, and Mitigations
+
+**Carefully think through the security implications for this change**
+
+What are the risks of this proposal and how do we mitigate. Think broadly. How
+will this impact the broader OKD ecosystem? Does this work in a managed services
+environment that has many tenants?
+
+How will security be reviewed and by whom? How will UX be reviewed and by whom?
+
+Consider including folks that also work outside your immediate sub-project.
+
+## Design Details
+
+### Test Plan
+
+**Note:** *Section not required until targeted at a release.*
+
+Consider the following in developing a test plan for this enhancement:
+- Will there be e2e and integration tests, in addition to unit tests?
+- How will it be tested in isolation vs with other components?
+
+No need to outline all of the test cases, just the general strategy. Anything
+that would count as tricky in the implementation and anything particularly
+challenging to test should be called out.
+
+All code is expected to have adequate tests (eventually with coverage
+expectations).
+
+### Upgrade / Downgrade Strategy
+
+If applicable, how will the component be upgraded and downgraded? Make sure this
+is in the test plan.
+
+Consider the following in developing an upgrade/downgrade strategy for this
+enhancement:
+- What changes (in invocations, configurations, API use, etc.) is an existing
+  cluster required to make on upgrade in order to...
+  -  keep previous behavior?
+  - make use of the enhancement?
+
+## Implementation History
+
+Major milestones in the life cycle of a proposal should be tracked in `Implementation
+History`.
+
+## Drawbacks
+
+The idea is to find the best form of an argument why this enhancement should _not_ be implemented.
+
+## Alternatives
+
+Similar to the `Drawbacks` section the `Alternatives` section is used to
+highlight and record other possible approaches to delivering the value proposed
+by an enhancement.
+
+## Infrastructure Needed [optional]
+
+Use this section if you need things from the project. Examples include a new
+subproject, repos requested, github details, and/or testing infrastructure.
+
+Listing these here allows the community to get the process for these resources
+started right away.

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -425,22 +425,69 @@ The role mapping policy can be expressed and edit by the UI as simple YAML.
 
 ```yaml
 groups:
-- any:
-  - g0 # group name
-  - g1 # group name
-  roles:
-  - r0
-  - r1
-- and:
-  - g2  # group name
-  - g3  # group name
-  roles:
-  - r2
-  - r3
-- any:
-  - dev*  # group name (glob)
-  roles:
-  - dev*  # group name (glob)
+  # 1. Full Administrators - Broad OR logic (multiple ways to be an admin)
+  - any:
+      - Engineering-Admins
+      - Platform-Admins
+      - IT-Admins
+      - SEC-Global-Admins
+    roles:
+      - admin
+
+  # 2. Managers - Usually requires both department + manager flag
+  - and:
+      - Engineering
+      - Engineering-Managers
+    roles:
+      - manager
+
+  # 3. Architects - Senior technical leadership
+  - any:
+      - Engineering-Architects
+      - Principal-Architects
+      - Solution-Architects
+      - Tech-Leads
+    roles:
+      - architect
+
+  # 4. Migrators - Teams allowed to run data/system migrations
+  - any:
+      - Engineering-Migration-Team
+      - Database-Admins
+      - SRE-Migration
+      - Platform-Migration
+    roles:
+      - migrator
+
+  # 5. Development teams - Any dev-related group gets base developer access
+  #    (you can later decide if "developer" should map to one of the above roles or be implicit)
+  - any:
+      - dev*
+      - engineering-*
+      - backend-*
+      - frontend-*
+      - mobile-*
+      - qa*
+      - sre*
+    roles:
+      - developer        # Optional base role - you can remove if not needed
+
+  # 6. Read-only access for support / auditors (common in engineering orgs)
+  - any:
+      - Helpdesk*
+      - IT-Support-RO
+      - Security-Auditors
+      - Compliance-Team
+    roles:
+      - readonly
+
+  # 7. Strict production admin access (example of tighter control)
+  - and:
+      - Engineering
+      - Prod-Admins
+    roles:
+      - admin
+      - migrator
 ```
 
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -104,10 +104,9 @@ permissions, tokens, PATs, and external identity mappings. Users are
 assigned to roles, and roles are associated with permissions (represented as
 OAuth scopes).
 
-The UI will be refactored to use OIDC for authentication (replacing the current
-Keycloak client integration) and will include new pages for managing users,
-roles, and permissions. The login page will be served from a ConfigMap managed
-by the operator, enabling branding customization without code changes.
+The web UI will be refactored to use OIDC with RFE [Adopt a modern OIDC flow on the UI](https://github.com/konveyor/enhancements/issues/268).  This will handle the login, token refresh, and expired/revoked token handling.
+
+To support the full Hub OIDC provider UX, base user management pages will be implemented and deployed to the operator.  These pages will include the login flow, user self management (i.e. change password), user management, role management, and permission management as needed.  In a federated configuration, this UX will be delegated to the federated OIDC provider.
 
 All standard OIDC discovery endpoints will be implemented
 (`.well-known/openid-configuration`, authorization, token, JWKS, userinfo,

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -76,8 +76,8 @@ High Level Model:
 
 ```mermaid
 erDiagram
-    USER ||o-o{ ROLE : "has"
-    ROLE ||o-o{ PERMISSION : "has"
+    USER }o--o{ ROLE : "granted"
+    ROLE }o--o{ PERMISSION : "has"
 
     USER {
         uint id PK
@@ -94,7 +94,7 @@ erDiagram
     PERMISSION {
         uint id PK
         string name "human readable name"
-        string scope "actual OIDC scope string"
+        string scope "OIDC scope"
     }
 ```
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -133,14 +133,14 @@ reports no vulnerabilities or backdoors.
 
 Resources:
 
-| Method        | Path            | Purpose                        |
-|---------------|-----------------|--------------------------------|
-| ANY           | /users          | User collection                |
-| ANY           | /roles          | Roles collection               |
-| GET           | /permissions    | Permission collection          |
-| GET \| DELETE | /tokens         | Issued tokens                  |
-| ANY           | /apikeys        | APIKey collection              |
-| GET           | /idp/identities | Remote IDP identity collection |
+| Method        | Path                 | Purpose                        |
+|---------------|----------------------|--------------------------------|
+| ANY           | /auth/users          | User collection                |
+| ANY           | /auth/roles          | Roles collection               |
+| GET           | /auth/permissions    | Permission collection          |
+| GET \| DELETE | /auth/tokens         | Issued tokens                  |
+| ANY           | /auth/apikeys        | APIKey collection              |
+| GET           | /auth/idp/identities | Remote IDP identity collection |
 
 
 Standard OIDC endpoints:

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -78,7 +78,7 @@ All sensitive information will be stored encrypted.
 
 Access tokens may be revoked (effective next refresh).
 
-### API Keys
+### API-Key
 
 Add support for API-Keys (Reference [RFE-266](https://github.com/konveyor/enhancements/issues/266)).
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -270,7 +270,6 @@ sequenceDiagram
     participant UI as UI / API Client
     participant Hub as Hub Provider<br>(OIDC Provider)
     participant ProtectedAPI as Protected API / Resource Server
-    participant DB as Database<br>(Optional)
 
     Note over UI,ProtectedAPI: Token Validation Flow (most common pattern)
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -1,5 +1,5 @@
 ---
-title: provide-builtin-authz
+title: provide-builtin-auth
 authors:
   - "jortel@redhat.com"
 reviewers:
@@ -11,9 +11,9 @@ last-updated: 2026-3-27
 status: implementable
 ---
 
-# Provide builtin AuthZ
+# Provide builtin Auth
 
-Add builtin AuthZ functionality so that KeyCloak is no longer required.
+Add builtin AuthN and AuthZ functionality so that KeyCloak is no longer required.
 
 
 ## Release Signoff Checklist

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -178,6 +178,7 @@ erDiagram
 #### Notes:
 - The Token table contains hub issued tokens.
 - The _expiration_ column is mainly used for reaping.
+- API-Key will be stored in the DB but cached in memory for performance and less pressure on the DB.
 
 ### Login
 
@@ -527,8 +528,6 @@ groups:
       - admin
       - migrator
 ```
-
-
 
 ### Test Plan
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -113,7 +113,7 @@ erDiagram
     TOKEN {
         uint id PK
         uint user_id
-        uint idp_identity_id FK nullable
+        uint idp_identity_id FK "0 = none" 
         string jti "jwt id"
         datetime expiration
         datetime revoked

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -142,6 +142,7 @@ Standard OIDC endpoints Provided by `go-oidc`
 erDiagram
     USER }o--o{ ROLE : "granted"
     ROLE }o--o{ PERMISSION : "has"
+    USER ||--o{ API_KEY : "owns"
     IDP_IDENTITY ||--|| USER : "EXTERNAL identity"
     IDP_IDENTITY ||--|| TOKEN : "delegated authentication"
 
@@ -162,7 +163,14 @@ erDiagram
         string name "human readable name"
         string scope "scope"
     }
-    
+
+    API_KEY {
+        uint id PK
+        uint user_id FK
+        string key "unique"
+        datetime expiration
+    }
+
     IDP_IDENTITY {
         uint id PK
         uint user_id FK
@@ -176,11 +184,11 @@ erDiagram
     
     TOKEN {
         uint id PK
-        uint user_id
-        uint idp_identity_id FK "0 = none" 
+        uint user_id FK
+        uint idp_identity_id FK "0 = none"
         string jti "jwt id"
         datetime expiration
-        datetime revoked
+        datetime revoked "nullable"
         datetime last_authenticated
         datetime last_refreshed
     }

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -52,6 +52,11 @@ Eliminate dependence on Keycloak.
 - To support explicit revocation of both access tokens and PATs for
   immediate credential invalidation.
 
+**Note**: Both Personal Access Tokens (PAT) and API-Key are opaque tokens. Typically, the difference is a PAT
+is tied to user and an API-Key is tied to an Service Account (SA).  In konveyor, a token tied to a task would more 
+technically be tied to an API-Key.  In konveyor, we don't plan to support service accounts so the terms will likely 
+be used interchangeably.
+
 ### Non-Goals
 
 ## Proposal

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -119,6 +119,7 @@ with these tokens.  However, new tasks will be configured to present API-Keys.
 Tokens and APIKeys are revoked by deletion.
 
 DELETE /auth/tokens/:id
+
 DELETE /auth/apikeys/:id
 
 ### Security, Risks, and Mitigations

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -54,9 +54,36 @@ Eliminate dependence on Keycloak.
 ## Proposal
 
 Make the hub an OIDC provider. The provider policy may be self-contained or configured
-to delegate authentication and/or authorization to an external provider. Th hub inventory
+to delegate authentication and/or authorization to an external provider. The hub inventory
 is augmented to include Users and Roles. Users may be associated to roles and roles may
 be associated to permissions (scopes).  Tokens will continue to contain scope claims.
+
+
+```mermaid
+erDiagram
+    USER ||--o{ USER_ROLE : "has many"
+    ROLE ||--o{ USER_ROLE : "belongs to many"
+
+    USER {
+        uint id PK
+        string username "unique"
+        string password "encrypted"
+        string email "unique"
+    }
+
+    ROLE {
+        uint id PK
+        string name "unique (e.g. admin, developer)"
+        string scopes "JSON serialized []string"
+    }
+
+    USER_ROLE {
+        uint user_id PK,FK
+        uint role_id PK,FK
+    }
+```
+
+Login:
 
 ```mermaid
 sequenceDiagram
@@ -106,7 +133,7 @@ sequenceDiagram
     Note over UI: UI now has tokens issued by Hub Provider<br>with local user identity + authorization from roles
 ```
 
-When and external provider is configured, the login page rendered by the hub will contain a
+Login when and external provider is configured, the login page rendered by the hub will contain a
 button for this.  For example: "Login with Google".
 
 ```mermaid
@@ -169,6 +196,84 @@ sequenceDiagram
     deactivate Hub
 
     Note over UI: UI now has tokens issued by the Hub Provider<br>containing both external identity + local authorization (roles/scopes)
+```
+
+Token validation:
+
+```mermaid
+sequenceDiagram
+    participant UI as UI / API Client
+    participant Hub as Hub Provider<br>(OIDC Provider)
+    participant ProtectedAPI as Protected API / Resource Server
+    participant DB as Database<br>(Optional)
+
+    Note over UI,ProtectedAPI: Token Validation Flow (most common pattern)
+
+    UI->>ProtectedAPI: GET /api/projects<br>Authorization: Bearer <access_token>
+    activate ProtectedAPI
+
+    ProtectedAPI->>ProtectedAPI: 1. Verify JWT Signature<br>(using Hub's JWKS)
+    ProtectedAPI->>ProtectedAPI: 2. Validate Standard Claims<br>(iss, aud, exp, nbf, iat)
+
+    alt Token is Invalid or Expired
+        ProtectedAPI-->>UI: 401 Unauthorized
+    else Token is Valid
+        ProtectedAPI->>ProtectedAPI: 3. Extract Claims<br>(sub, scope, roles if present)
+
+        %% Optional: Extra authorization check using your DB
+        ProtectedAPI->>DB: 4. Optional: Lookup user roles<br>by sub (username)
+        DB-->>ProtectedAPI: Current roles & scopes
+
+        ProtectedAPI->>ProtectedAPI: 5. Check Required Scopes<br>e.g. HasScope("api:read") or role-based check
+
+        alt Authorization Failed
+            ProtectedAPI-->>UI: 403 Forbidden
+        else Authorization Passed
+            ProtectedAPI-->>UI: 200 OK + Response Data
+        end
+    end
+
+    deactivate ProtectedAPI
+
+    Note over ProtectedAPI: Common Validation Order:<br>1. Signature + Issuer<br>2. Expiration<br>3. Audience<br>4. Scopes / Claims<br>5. Custom business rules
+```
+
+Token validation with external provider:
+
+```mermaid
+sequenceDiagram
+    participant UI as UI / Client
+    participant Hub as Hub Provider
+    participant ProtectedAPI as Protected API
+    participant DB as Database
+    participant ExternalIdP as External IdP (Google, etc.)
+
+    Note over Hub,DB: During initial login: Store external refresh_token linked to local user
+
+    UI->>ProtectedAPI: Request with Hub access_token
+    activate ProtectedAPI
+
+    ProtectedAPI->>ProtectedAPI: Verify Hub JWT signature + claims
+    ProtectedAPI->>DB: Lookup user + stored external refresh_token
+
+    alt Re-validation Enabled
+        ProtectedAPI->>ExternalIdP: Attempt refresh<br>(POST /token with refresh_token)
+        ExternalIdP-->>ProtectedAPI: Success → new external tokens<br>OR Failure (invalid_grant / revoked)
+        
+        alt External Refresh Failed (Revoked)
+            ProtectedAPI->>ProtectedAPI: Mark session as invalid / force re-login
+            ProtectedAPI-->>UI: 401 Unauthorized + prompt to re-authenticate
+        else External Refresh Succeeded
+            ProtectedAPI->>ProtectedAPI: Optional: Update stored tokens
+            ProtectedAPI->>ProtectedAPI: Check local roles/scopes
+            ProtectedAPI-->>UI: 200 OK
+        end
+    else No Re-validation (simple mode)
+        ProtectedAPI->>DB: Only check local user status + roles
+        ProtectedAPI-->>UI: 200 OK (until Hub token expires)
+    end
+
+    deactivate ProtectedAPI
 ```
 
 The UI will be updated to use OIDC (instead of keycloak) and be configured to use the

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -65,6 +65,12 @@ The Tackle CR will support configuring the hub to use an external OIDC provider 
 configure or seed it.  The installation and configuration of an external provider is the sole responsibility 
 of the user.
 
+The UI fragment used for the login page will be read from a ConfigMap managed by the operator.  Branding
+customizations will be handled by the operator.
+
+Publish a README.md that contains expected roles and a catalog of scopes to support user's bringing their
+own external OIDC provider. This _may_ also include a recommended keycloak Realm specification.
+
 ### Security, Risks, and Mitigations
 
 The [go-oidc](https://github.com/luikyv/go-oidc) package is **OpenID certified** and is actively maintained. It has no reported CVEs.  AI code analysis

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -101,10 +101,6 @@ expiration: # OPTIONAL
 key: cvP1sjff7_X2dCEIzUPf8f0IzKSbwiSDf1dZChZuRxY
 ```
 
-#### Revocation
-
-DELETE /auth/apikey/:id
-
 #### Authentication
 
 HTTP requests with header: Authentication: Bearer `<key>` is detected and validated:
@@ -118,6 +114,12 @@ Refit task manager and addon API authorization to use API-Key instead of custom 
 For backwards compatibility, Tokens with SigningMethod=HMAC still honored to support in-flight tasks
 with these tokens.  However, new tasks will be configured to present API-Keys.
 
+### Revocation
+
+Tokens and APIKeys are revoked by deletion.
+
+DELETE /auth/tokens/:id
+DELETE /auth/apikeys/:id
 
 ### Security, Risks, and Mitigations
 
@@ -128,19 +130,39 @@ reports no vulnerabilities or backdoors.
 
 ### Routes/Endpoints
 
-Standard OIDC endpoints Provided by `go-oidc`
+Resources:
 
-| Method | Endpoint Path                       | Purpose |
-|--------|-------------------------------------|---------|
-| GET    | `/.well-known/openid-configuration` | Discovery document – Tells clients all the endpoints, supported scopes, grant types, etc. |
+| Method        | Path            | Purpose                        |
+|---------------|-----------------|--------------------------------|
+| ANY           | /users          | User collection                |
+| ANY           | /roles          | Roles collection               |
+| GET           | /permissions    | Permission collection          |
+| GET \| DELETE | /tokens         | Issued tokens                  |
+| ANY           | /apikeys        | APIKey collection              |
+| GET           | /idp/identities | Remote IDP identity collection |
+
+
+Standard OIDC endpoints:
+
+| Method | Path                                | Purpose                                                                                        |
+|--------|-------------------------------------|------------------------------------------------------------------------------------------------|
+| GET    | `/.well-known/openid-configuration` | Discovery document – Tells clients all the endpoints, supported scopes, grant types, etc.      |
 | GET    | `/oidc/authorize`                   | Authorization Endpoint – Starts the login flow (shows login form or redirects to external IdP) |
-| POST   | `/oidc/token`                       | Token Endpoint – Exchanges authorization code for access_token + id_token + refresh_token |
-| GET    | `/oidc/jwks`                        | JSON Web Key Set – Public keys used by clients to verify your JWT signatures |
-| GET    | `/oidc/userinfo`                    | UserInfo Endpoint – Returns user claims (optional, but commonly used) |
-| POST   | `/oidc/introspect`                  | Token Introspection – Allows resource servers to validate opaque tokens (optional) |
-| POST   | `/oidc/revoke`                      | Token Revocation – Allows clients to revoke refresh tokens (optional but recommended) |
+| POST   | `/oidc/token`                       | Token Endpoint – Exchanges authorization code for access_token + id_token + refresh_token      |
+| GET    | `/oidc/jwks`                        | JSON Web Key Set – Public keys used by clients to verify your JWT signatures                   |
+| GET    | `/oidc/userinfo`                    | UserInfo Endpoint – Returns user claims (optional, but commonly used)                          |
+| POST   | `/oidc/introspect`                  | Token Introspection – Allows resource servers to validate opaque tokens (optional)             |
+| POST   | `/oidc/revoke`                      | Token Revocation – Allows clients to revoke refresh tokens (optional but recommended)          |
 
 ### High Level Model:
+
+Entities:
+- User - known users.
+- Role - named groups of permissions (scopes).
+- Permission - named permissions mapped to a scopes. 
+- IdpIdentity - identities authenticated by remote Idp provider. Contains the refresh token.
+- Token - issued (valid) tokens. 
+- APIKey - issued (valid) API-Keys.
 
 ```mermaid
 erDiagram
@@ -194,9 +216,6 @@ erDiagram
         uint idp_identity_id FK "0 = none"
         string jti "jwt id"
         datetime expiration
-        datetime revoked "nullable"
-        datetime last_authenticated
-        datetime last_refreshed
     }
     
     TASK {
@@ -206,8 +225,8 @@ erDiagram
 
 #### Notes:
 - The Token table contains hub issued tokens.
-- The _expiration_ column is mainly used for reaping.
-- API-Key will be stored (encrypted) in the DB but cached in memory for performance and less pressure on the DB.
+- The Token._expiration_ column is mainly used for reaping.
+- API-Key stored in the DB but cached in memory for performance and mitigate DB pressure.
 
 ### Login
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -106,9 +106,9 @@ The task manager and addon API will be refactored to use API keys instead of cus
 
 API keys support optional expiration dates and can be explicitly revoked. The keys themselves are not stored in the database—only cryptographic digests—ensuring that compromise of the database does not directly expose API keys.
 
-#### Integration
+#### Tools Integration
 
-Client tools such as KAI and Kantra should authenticate by getting an API-Key.  This is almost exactly like the current
+Client tools such as **Kantra** and **KAI** should authenticate by getting an API-Key.  This is almost exactly like the current
 process of getting a (JWT) token (POST `/auth/login`), the client will POST to a new endpoint that instead returns an API-Key.
 The returned key is specified in future requests using authentication header: `Authentication Bearer <key>`.
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -108,9 +108,9 @@ API keys support optional expiration dates and can be explicitly revoked. The ke
 
 #### Integration
 
-Client tools such as KAI and Kantra will obtain an API-Key by posting to the API-Key endpoint.  The
-request body will include the userid, password and _optional_ lifespan (minutes). For Go clients
-such as Kantra, this will behave much like the current token-based authentication.
+Client tools such as KAI and Kantra should authenticate by getting an API-Key.  This is almost exactly like the current
+process of getting a (JWT) token (POST `/auth/login`), the client will POST to a new endpoint that instead returns an API-Key.
+The returned key is specified in future requests using authentication header: `Authentication Bearer <key>`.
 
 #### Task-Scoped Authentication
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -74,7 +74,7 @@ reports no vulnerabilities or backdoors.
 
 ### Routes/Endpoints
 
-OIDC _standard_ endpoints Provided by `go-oidc`
+Standard OIDC endpoints Provided by `go-oidc`
 
 | Method | Endpoint Path                       | Purpose |
 |--------|-------------------------------------|---------|

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -78,8 +78,8 @@ High Level Model:
 erDiagram
     USER }o--o{ ROLE : "granted"
     ROLE }o--o{ PERMISSION : "has"
-    IDP_IDENTITY ||--|| USER : "mapped"
-    IDP_IDENTITY ||--|| TOKEN : "user authenticated by"
+    IDP_IDENTITY ||--|| USER : "EXTERNAL identity"
+    IDP_IDENTITY ||--|| TOKEN : "delegated authentication"
 
     USER {
         uint id PK

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -85,7 +85,9 @@ Add support for API-Keys (Reference [RFE-266](https://github.com/konveyor/enhanc
 #### Generation
 
 POST /auth/apikey returns a 256-bit base64URL-encoded generated key which has been stored in the DB along 
-with associated permissions (scopes).
+with associated permissions (scopes). The API key inherits all permissions (scopes) from the user who creates it,
+based on their assigned roles at the time of creation.
+
 Body:
 ```yaml
 expiration: # OPTIONAL
@@ -498,7 +500,22 @@ sequenceDiagram
 
 #### Policy
 
-The role mapping policy can be expressed and edit by the UI as simple YAML.
+The role mapping policy can be expressed and edited by the UI as simple YAML. This policy maps LDAP/Active Directory 
+group memberships to internal roles, which in turn define the user's permissions (scopes).
+
+**Schema:**
+- Each mapping rule contains a conditional expression (`any` or `and`) and a list of `roles` to assign
+- **`any`**: User matches if they belong to **at least one** of the listed groups (logical OR)
+- **`and`**: User matches if they belong to **all** of the listed groups (logical AND)
+- **`roles`**: List of internal role names to assign when the condition matches
+
+**Evaluation:**
+- All rules are evaluated for each user during authentication
+- A user may match multiple rules and accumulate roles from all matches
+- The final set of permissions (scopes) is derived from the union of all assigned roles
+- Group names are matched exactly (case-sensitive) against the groups returned from LDAP/AD
+
+**Example policy:**
 
 ```yaml
 groups:

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -225,8 +225,8 @@ while maintaining compatibility with OIDC client expectations.
 - HMAC-signed tokens are deprecated but maintained for backwards compatibility
 - Tokens and PATs can be explicitly revoked with immediate (PATs) or
   deferred (tokens on next refresh) effect
-- OIDC clients are configured via operator-managed Secrets rather than stored in
-  the database
+- OIDC clients and external IdP configurations are managed via operator-controlled
+  Secret (`hub-oidc`) rather than stored in the database
 
 #### External Provider Integration
 
@@ -280,19 +280,115 @@ The UI deployment will be configured to authenticate against the Hub's OIDC prov
   - `OIDC_REDIRECT_URI`: Callback URL for the authorization code flow (e.g., `https://ui.konveyor.io/auth/callback`)
   - `OIDC_SCOPES`: Requested scopes (e.g., `openid profile email`)
 
-#### Client Registration
+#### OIDC Configuration Secret
 
-- The operator will seed the Hub with OIDC client configurations via ConfigMap, including:
-  - UI client definition (client_id, allowed redirect URIs, allowed scopes)
-  - Any additional clients for tools or integrations
-  - This ConfigMap will be mounted into the Hub and read at startup
+- The operator will seed the Hub with all OIDC-related configuration via a single Secret (`hub-oidc`):
+  - **Client registrations** (`clients:` section): UI client, tool clients, etc.
+  - **External IdP configurations** (`idp:` section): Keycloak, Google, LDAP, etc.
+  - This Secret will be mounted into the Hub at `/etc/hub/` and read at startup (file: `/etc/hub/oidc.yaml`)
+  
+Example structure:
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hub-oidc
+  namespace: konveyor-tackle
+type: Opaque
+stringData:
+  oidc.yaml: |
+    clients:
+      - clientId: konveyor-ui
+        clientSecret: <ui-client-secret>
+        redirectURIs:
+          - https://ui.konveyor.io/auth/callback
+        scopes:
+          - openid
+          - profile
+          - email
+      - clientId: kantra-cli
+        clientSecret: <kantra-client-secret>
+        redirectURIs:
+          - http://localhost:*
+        scopes:
+          - openid
+          - profile
+    
+    idp:
+      - kind: oidc
+        name: keycloak
+        issuer: "https://keycloak.example.com/realms/konveyor"
+        clientId: "tackle-hub"
+        clientSecret: "<keycloak-client-secret>"
+        scopes:
+          - openid
+          - profile
+          - email
+```
 
 #### Migration Support
 
-For existing deployments currently using Keycloak:
-- The operator will support a migration mode where Keycloak can be configured as an external OIDC provider
-- A configuration flag or CR annotation will control whether to deploy Keycloak or use the built-in provider
-- Documentation will be provided for migrating users from Keycloak to local Hub authentication
+For existing deployments currently using Keycloak, the operator will automatically migrate the 
+authentication architecture to use the Hub's built-in OIDC provider with Keycloak configured as an 
+external (federated) IdP.
+
+##### Current Keycloak Configuration (Pre-Migration)
+
+Currently, Keycloak integration is configured via environment variables in the Hub deployment:
+- `AUTH_REQUIRED` - Enable/disable authentication (e.g., `true`)
+- `KEYCLOAK_HOST` - Keycloak server URL (e.g., `https://keycloak.example.com`)
+- `KEYCLOAK_REALM` - Realm name (e.g., `konveyor`)
+- `KEYCLOAK_CLIENT_ID` - Client identifier for the Hub (e.g., `tackle-hub`)
+- `KEYCLOAK_CLIENT_SECRET` - Client secret (stored in Secret)
+- Additional realm-specific settings
+
+##### Migration Process
+
+When the operator detects an existing deployment with Keycloak authentication 
+enabled (`AUTH_REQUIRED=true`), it will:
+
+1. **Extract Keycloak configuration** from the current Hub deployment environment variables and Secrets
+
+2. **Update the OIDC configuration Secret** (`hub-oidc`) to include Keycloak as an external IdP in the `idp:` section:
+   ```yaml
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     name: hub-oidc
+     namespace: konveyor-tackle
+   type: Opaque
+   stringData:
+     oidc.yaml: |
+       clients:
+         - clientId: konveyor-ui
+           clientSecret: <ui-client-secret>
+           redirectURIs:
+             - https://ui.konveyor.io/auth/callback
+           scopes:
+             - openid
+             - profile
+             - email
+       
+       idp:
+         - kind: oidc
+           name: keycloak
+           issuer: "https://keycloak.example.com/realms/konveyor"
+           clientId: "tackle-hub"
+           clientSecret: "<keycloak-client-secret>"
+           scopes:
+             - openid
+             - profile
+             - email
+   ```
+
+3. **Update Hub deployment** to:
+   - Remove Keycloak-specific environment variables
+   - Ensure the `hub-oidc` Secret is mounted at `/etc/hub/`
+
+5. **Preserve Keycloak deployment** (optional):
+   - If `spec.keycloak.enabled=true` in the Tackle CR, the operator continues to deploy and manage Keycloak
+   - If `spec.keycloak.enabled=false`, the operator stops managing Keycloak but retains the external IdP configuration
+   - This allows administrators to choose whether to keep or remove Keycloak from the deployment
 
 ### Security, Risks, and Mitigations
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -85,12 +85,12 @@ Standard OIDC endpoints Provided by `go-oidc`
 | Method | Endpoint Path                       | Purpose |
 |--------|-------------------------------------|---------|
 | GET    | `/.well-known/openid-configuration` | Discovery document – Tells clients all the endpoints, supported scopes, grant types, etc. |
-| GET    | `/oauth2/authorize`                 | Authorization Endpoint – Starts the login flow (shows login form or redirects to external IdP) |
-| POST   | `/oauth2/token`                     | Token Endpoint – Exchanges authorization code for access_token + id_token + refresh_token |
-| GET    | `/oauth2/jwks`                      | JSON Web Key Set – Public keys used by clients to verify your JWT signatures |
-| GET    | `/oauth2/userinfo`                  | UserInfo Endpoint – Returns user claims (optional, but commonly used) |
-| POST   | `/oauth2/introspect`                | Token Introspection – Allows resource servers to validate opaque tokens (optional) |
-| POST   | `/oauth2/revoke`                    | Token Revocation – Allows clients to revoke refresh tokens (optional but recommended) |
+| GET    | `/oidc/authorize`                   | Authorization Endpoint – Starts the login flow (shows login form or redirects to external IdP) |
+| POST   | `/oidc/token`                     | Token Endpoint – Exchanges authorization code for access_token + id_token + refresh_token |
+| GET    | `/oidc/jwks`                      | JSON Web Key Set – Public keys used by clients to verify your JWT signatures |
+| GET    | `/oidc/userinfo`                  | UserInfo Endpoint – Returns user claims (optional, but commonly used) |
+| POST   | `/oidc/introspect`                | Token Introspection – Allows resource servers to validate opaque tokens (optional) |
+| POST   | `/oidc/revoke`                    | Token Revocation – Allows clients to revoke refresh tokens (optional but recommended) |
 
 ### High Level Model:
 
@@ -284,13 +284,7 @@ sequenceDiagram
         ProtectedAPI-->>UI: 401 Unauthorized
     else Token is Valid
         ProtectedAPI->>ProtectedAPI: 3. Extract Claims<br>(sub, scope, roles if present)
-
-        %% Optional: Extra authorization check using your DB
-        ProtectedAPI->>DB: 4. Optional: Lookup user roles<br>by sub (username)
-        DB-->>ProtectedAPI: Current roles & scopes
-
-        ProtectedAPI->>ProtectedAPI: 5. Check Required Scopes<br>e.g. HasScope("api:read") or role-based check
-
+        ProtectedAPI->>ProtectedAPI: 4. Check Required Scopes<br>e.g. HasScope("api:read") or role-based check
         alt Authorization Failed
             ProtectedAPI-->>UI: 403 Forbidden
         else Authorization Passed
@@ -334,7 +328,6 @@ sequenceDiagram
             ProtectedAPI-->>UI: 200 OK
         end
     else No Re-validation (simple mode)
-        ProtectedAPI->>DB: Only check local user status + roles
         ProtectedAPI-->>UI: 200 OK (until Hub token expires)
     end
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -74,9 +74,7 @@ reports no vulnerabilities or backdoors.
 
 ### Routes/Endpoints
 
-### OIDC Endpoints Provided by `luikyv/go-oidc`
-
-These endpoints are automatically handled by the library when you mount `op.Handler()`.
+OIDC Endpoints Provided by `go-oidc`
 
 | Method | Endpoint Path                       | Purpose |
 |--------|-------------------------------------|---------|

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -140,7 +140,7 @@ reports no vulnerabilities or backdoors.
 
 ## Design Details
 
-See [DESIGN.md](./DESIGN.md) for complete technical specifications including:
+See [DESIGN.md](./DESIGN.md) for complete technical specifications (for illustration not approval) including:
 - API endpoints and routes
 - Data model and entity relationships
 - Authentication flow diagrams (local, external OIDC, LDAP/AD)

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -78,6 +78,8 @@ All sensitive information will be stored encrypted.
 
 Access tokens may be revoked (effective next refresh).
 
+Clients will be loaded from a ConfigMap seeded by the operator.
+
 ### API-Key
 
 Add support for API-Keys (Reference [RFE-266](https://github.com/konveyor/enhancements/issues/266)).
@@ -169,7 +171,7 @@ erDiagram
     API_KEY {
         uint id PK
         uint user_id FK
-        string key "unique (encrypted)"
+        string digest "unique"
         datetime expiration
     }
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -283,48 +283,9 @@ The UI deployment will be configured to authenticate against the Hub's OIDC prov
 #### OIDC Configuration Secret
 
 - The operator will seed the Hub with all OIDC-related configuration via a single Secret (`hub-oidc`):
-  - **Client registrations** (`clients:` section): UI client, tool clients, etc.
-  - **External IdP configurations** (`idp:` section): Keycloak, Google, LDAP, etc.
-  - This Secret will be mounted into the Hub at `/etc/hub/` and read at startup (file: `/etc/hub/oidc.yaml`)
-  
-Example structure:
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: hub-oidc
-  namespace: konveyor-tackle
-type: Opaque
-stringData:
-  oidc.yaml: |
-    clients:
-      - clientId: konveyor-ui
-        clientSecret: <ui-client-secret>
-        redirectURIs:
-          - https://ui.konveyor.io/auth/callback
-        scopes:
-          - openid
-          - profile
-          - email
-      - clientId: kantra-cli
-        clientSecret: <kantra-client-secret>
-        redirectURIs:
-          - http://localhost:*
-        scopes:
-          - openid
-          - profile
-    
-    idp:
-      - kind: oidc
-        name: keycloak
-        issuer: "https://keycloak.example.com/realms/konveyor"
-        clientId: "tackle-hub"
-        clientSecret: "<keycloak-client-secret>"
-        scopes:
-          - openid
-          - profile
-          - email
-```
+  - **Client registrations**: UI client, CLI tool clients, etc. with their credentials and allowed scopes
+  - **External IdP configurations**: Keycloak, Google, LDAP, etc. with connection details and credentials
+  - This Secret will be mounted into the Hub at `/etc/hub/` and read at startup
 
 #### Migration Support
 
@@ -349,25 +310,13 @@ enabled (`AUTH_REQUIRED=true`), it will:
 
 1. **Extract Keycloak configuration** from the current Hub deployment environment variables and Secrets
 
-2. **Update the OIDC configuration Secret** (`hub-oidc`) to include Keycloak as an external IdP in the `idp:` section:
-   ```yaml
-   idp:
-     - kind: oidc
-       name: keycloak
-       issuer: "https://keycloak.example.com/realms/konveyor"
-       clientId: "tackle-hub"
-       clientSecret: "<keycloak-client-secret>"
-       scopes:
-         - openid
-         - profile
-         - email
-   ```
-   
-   See the "OIDC Configuration Secret" section above for the complete Secret structure.
+2. **Create or update the OIDC configuration Secret** (`hub-oidc`) to include:
+   - Client registrations (UI, tools, etc.)
+   - Keycloak as an external IdP with its issuer URL, client credentials, and scopes
 
 3. **Update Hub deployment** to:
    - Remove Keycloak-specific environment variables
-   - Ensure the `hub-oidc` Secret is mounted at `/etc/hub/`
+   - Mount the `hub-oidc` Secret at `/etc/hub/`
 
 5. **Preserve Keycloak deployment** (optional):
    - If `spec.keycloak.enabled=true` in the Tackle CR, the operator continues to deploy and manage Keycloak

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -72,7 +72,23 @@ reports no vulnerabilities or backdoors.
 
 ## Design Details
 
-High Level Model:
+### Routes/Endpoints
+
+### OIDC Endpoints Provided by `luikyv/go-oidc`
+
+These endpoints are automatically handled by the library when you mount `op.Handler()`.
+
+| Method | Endpoint Path                       | Purpose |
+|--------|-------------------------------------|---------|
+| GET    | `/.well-known/openid-configuration` | Discovery document – Tells clients all the endpoints, supported scopes, grant types, etc. |
+| GET    | `/oauth2/authorize`                 | Authorization Endpoint – Starts the login flow (shows login form or redirects to external IdP) |
+| POST   | `/oauth2/token`                     | Token Endpoint – Exchanges authorization code for access_token + id_token + refresh_token |
+| GET    | `/oauth2/jwks`                      | JSON Web Key Set – Public keys used by clients to verify your JWT signatures |
+| GET    | `/oauth2/userinfo`                  | UserInfo Endpoint – Returns user claims (optional, but commonly used) |
+| POST   | `/oauth2/introspect`                | Token Introspection – Allows resource servers to validate opaque tokens (optional) |
+| POST   | `/oauth2/revoke`                    | Token Revocation – Allows clients to revoke refresh tokens (optional but recommended) |
+
+### High Level Model:
 
 ```mermaid
 erDiagram
@@ -122,11 +138,11 @@ erDiagram
     }
 ```
 
-Notes:
+#### Notes:
 - The Token table contains hub issued tokens.
 - The _expiration_ column is mainly used for reaping.
 
-**Basic** Login:
+### Login
 
 ```mermaid
 sequenceDiagram
@@ -176,7 +192,9 @@ sequenceDiagram
     Note over UI: UI now has tokens issued by Hub Provider<br>with local user identity + authorization from roles
 ```
 
-**Login** when and external provider is configured, the login page rendered by the hub will contain a
+### Login (external Authentication)
+
+when and external provider is configured, the login page rendered by the hub will contain a
 button for this.  For example: "Login with Google".
 
 ```mermaid
@@ -241,7 +259,7 @@ sequenceDiagram
     Note over UI: UI now has tokens issued by the Hub Provider<br>containing both external identity + local authorization (roles/scopes)
 ```
 
-Token **Validation**:
+### Token Validation
 
 ```mermaid
 sequenceDiagram
@@ -281,7 +299,7 @@ sequenceDiagram
     Note over ProtectedAPI: Common Validation Order:<br>1. Signature + Issuer<br>2. Expiration<br>3. Audience<br>4. Scopes / Claims<br>5. Custom business rules
 ```
 
-Token **validation** with external provider:
+### Token validation (external authentication)
 
 ```mermaid
 sequenceDiagram

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -184,9 +184,10 @@ Authentication options include:
 
 1. **Manual PAT configuration**: Users obtain a PAT through the Hub UI and provide it to Kantra
    via command line option (e.g., `--token`) or environment variable (e.g., `TOKEN`)
-2. **Device code flow**: Kantra initiates an OIDC device authorization flow, displays a code and
+2. **AC (device access grant)**: Kantra initiates an OIDC device authorization flow, displays a code and
    URL for the user to visit in a browser, completes authentication, then optionally requests a
-   PAT for long-lived access
+   PAT for long-lived access.  The Go binding will support this flow so if kantra used the binding,
+   it will get this for free.   
 
 The previous method of POSTing username/password directly to obtain a token is no longer
 supported. This approach relied on the OAuth 2.0 Resource Owner Password Credentials (Direct

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -69,7 +69,7 @@ be associated to permissions (scopes).  Tokens will continue to contain scope cl
 ```mermaid
 sequenceDiagram
     participant UI as UI (Client Application)
-    participant Hub as Hub Provider<br>(OIDC Provider)
+    participant Hub as Hub <br>(OIDC Provider)
     participant User as User
     participant DB as Database<br>(Users + Roles)
 
@@ -135,7 +135,7 @@ button for this.  For example: "Login with Google".
 ```mermaid
 sequenceDiagram
     participant UI as UI (Client Application)
-    participant Hub as Hub Provider<br>(OIDC Broker)
+    participant Hub as Hub <br>(OIDC Broker)
     participant ExternalIdP as External IdP<br>(e.g. Google)
     participant User as User
     participant DB as Database<br>(Users + Roles)

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -53,74 +53,58 @@ Eliminate dependence on Keycloak.
 
 ## Proposal
 
-### OIDC
+This proposal transforms the Hub into an OIDC-compliant identity provider, eliminating the hard dependency on Keycloak while providing flexible authentication options.
 
-Make the hub an OIDC provider. The security policy may be self-contained or configured
-to delegate authentication and/or authorization to an external provider. The hub inventory
-is augmented to include Users and Roles. Users may be associated to roles and roles may
-be associated to permissions (scopes).
+### User Stories
 
-The UI will be updated to use OIDC (instead of keycloak) and be configured to use the
-hub OIDC provider.  The UI will have pages to manage user, roles and permissions.
+**As a cluster administrator**, I want to deploy Konveyor without requiring Keycloak, so that I can reduce infrastructure complexity and resource overhead.
 
-The UI fragment used for the login page will be read from a ConfigMap managed by the operator.  Branding
-customizations will be handled by the operator.
+**As a security administrator**, I want to integrate Konveyor with my organization's existing identity provider (OIDC, LDAP, or Active Directory), so that I can enforce centralized authentication policies and maintain a single source of truth for user identities.
 
-The hub may be configured to integrate with external (remote) auth providers. The primary mechanism will be OIDC but will
-also support LDAP/ActiveDirectory.  In both cases, scopes (OIDC) and groups (LDAP) may need to be mapped to tackle roles. External
-providers may be created, updated and deleted using the UI/API. Configuration includes connection information
-credentials and group:role mapping rules. 
+**As a developer**, I want to use API keys for programmatic access to Konveyor APIs, so that I can build automated integrations without managing user credentials.
 
-Publish a README.md that contains expected roles and a catalog of scopes to support user's bringing their
-own external OIDC provider. This _may_ also include a recommended keycloak Realm specification.
+**As a Hub administrator**, I want to manage users, roles, and permissions directly within the Hub UI, so that I can control access without needing to configure external identity systems for simple deployments.
 
-All sensitive information will be stored encrypted.
+### High-Level Approach
 
-Access tokens may be revoked (effective next refresh).
+#### OIDC Provider
 
-Clients will be loaded from a ConfigMap seeded by the operator.
+The Hub will implement a standards-compliant OIDC provider supporting the authorization code flow with PKCE. This provider can operate in several modes:
 
-### API-Key
+1. **Self-contained mode**: Users, roles, and permissions are managed entirely within the Hub's inventory. Authentication uses locally stored credentials.
 
-Add support for API-Keys (Reference [RFE-266](https://github.com/konveyor/enhancements/issues/266)).
+2. **External OIDC delegation**: The Hub acts as an OIDC broker, delegating authentication to external providers (Google, Keycloak, Okta, etc.) while maintaining local authorization (role and permission management). This allows organizations to leverage existing identity providers while keeping fine-grained access control within Konveyor.
 
-#### Generation
+3. **LDAP/Active Directory integration**: The Hub authenticates users against LDAP or Active Directory using the standard bind pattern, queries group memberships, and maps groups to local roles using configurable YAML-based rules.
 
-POST /auth/apikey returns a 256-bit base64URL-encoded generated key which has been stored in the DB along 
-with associated permissions (scopes). The API key inherits all permissions (scopes) from the user who creates it,
-based on their assigned roles at the time of creation.
+The Hub inventory will be extended with new entities for users, roles, permissions, tokens, API keys, and external identity mappings. Users are assigned to roles, and roles are associated with permissions (represented as OAuth scopes). See [DESIGN.md](./DESIGN.md) for the complete data model.
 
-Body:
-```yaml
-expiration: # OPTIONAL
-```
-Returned:
-```yaml
-id: 18
-expiration: # OPTIONAL
-key: cvP1sjff7_X2dCEIzUPf8f0IzKSbwiSDf1dZChZuRxY
-```
+The UI will be refactored to use OIDC for authentication (replacing the current Keycloak client integration) and will include new pages for managing users, roles, and permissions. The login page will be served from a ConfigMap managed by the operator, enabling branding customization without code changes.
 
-#### Authentication
+All standard OIDC discovery endpoints will be implemented (`.well-known/openid-configuration`, authorization, token, JWKS, userinfo, introspection, and revocation), allowing any OIDC-compliant client to integrate with the Hub.
 
-HTTP requests with header: Authentication: Bearer `<key>` is detected and validated:
-1. Find/match stored key.
-2. Get mapped permissions (scopes).
-3. Authorize endpoint access.
+#### API Key Authentication
 
-#### Addon tokens
+API keys provide a secure mechanism for programmatic access, addressing [RFE-266](https://github.com/konveyor/enhancements/issues/266). Users can generate API keys through the Hub API, which inherit the user's permissions at the time of creation. Keys are presented as Bearer tokens and validated using the same scope-based authorization model as JWT tokens.
 
-Refit task manager and addon API authorization to use API-Key instead of custom JWT token generation.
-For backwards compatibility, Tokens with SigningMethod=HMAC still honored to support in-flight tasks
-with these tokens.  However, new tasks will be configured to present API-Keys.
+The task manager and addon API will be refactored to use API keys instead of custom HMAC-signed JWTs. For backwards compatibility, existing HMAC tokens will continue to be honored for in-flight tasks.
 
-### Revocation
+API keys support optional expiration dates and can be explicitly revoked. The keys themselves are not stored in the database—only cryptographic digests—ensuring that compromise of the database does not directly expose API keys.
 
-Deletion revokes tokens and API-Keys.
+#### Security Considerations
 
-DELETE /auth/tokens/:id
+- All sensitive data (passwords, refresh tokens) will be stored encrypted
+- API keys are stored as hashed digests, never in plain text
+- Token validation supports both RSA-signed JWTs (via JWKS) and API keys
+- HMAC-signed tokens are deprecated but maintained for backwards compatibility
+- Tokens and API keys can be explicitly revoked with immediate (API keys) or deferred (tokens on next refresh) effect
+- OIDC clients are configured via operator-managed ConfigMaps rather than stored in the database
 
-DELETE /auth/apikeys/:id
+#### External Provider Integration
+
+When configured with external providers, the Hub stores refresh tokens (encrypted) to enable ongoing validation. For LDAP/AD integrations, group-to-role mapping is expressed as simple YAML rules supporting both "any" (OR) and "and" (AND) logic, allowing flexible policy definition without code changes.
+
+A README will be published documenting the expected roles and permission scopes catalog to support administrators who want to configure external OIDC providers or Keycloak realms to work with the Hub.
 
 ### Security, Risks, and Mitigations
 
@@ -129,477 +113,35 @@ reports no vulnerabilities or backdoors.
 
 ## Design Details
 
-### Routes/Endpoints
-
-Resources:
-
-| Method        | Path                 | Purpose                        |
-|---------------|----------------------|--------------------------------|
-| ANY           | /auth/users          | User collection                |
-| ANY           | /auth/roles          | Roles collection               |
-| GET           | /auth/permissions    | Permission collection          |
-| GET \| DELETE | /auth/tokens         | Issued tokens                  |
-| ANY           | /auth/apikeys        | API-Key collection             |
-| GET           | /auth/idp/identities | Remote IDP identity collection |
-
-
-Standard OIDC endpoints:
-
-| Method | Path                              | Purpose                                                                                        |
-|--------|-----------------------------------|------------------------------------------------------------------------------------------------|
-| GET    | /.well-known/openid-configuration | Discovery document – Tells clients all the endpoints, supported scopes, grant types, etc.      |
-| GET    | /oidc/authorize                   | Authorization Endpoint – Starts the login flow (shows login form or redirects to external IdP) |
-| POST   | /oidc/token                       | Token Endpoint – Exchanges authorization code for access_token + id_token + refresh_token      |
-| GET    | /oidc/jwks                        | JSON Web Key Set – Public keys used by clients to verify your JWT signatures                   |
-| GET    | /oidc/userinfo                    | UserInfo Endpoint – Returns user claims (optional, but commonly used)                          |
-| POST   | /oidc/introspect                  | Token Introspection – Allows resource servers to validate opaque tokens (optional)             |
-| POST   | /oidc/revoke                      | Token Revocation – Allows clients to revoke refresh tokens (optional but recommended)          |
-
-### High Level Model:
-
-Entities:
-- User - known users.
-- Role - named groups of permissions (scopes).
-- Permission - named permissions mapped to a scopes. 
-- IdpIdentity - identities authenticated by remote Idp provider. Contains the refresh token.
-- Token - issued (valid) tokens. 
-- APIKey - issued (valid) API-Keys.
-
----
-
-```mermaid
-erDiagram
-    USER }o--o{ ROLE : "granted"
-    ROLE }o--o{ PERMISSION : "has"
-    USER ||--o{ API_KEY : "owns"
-    TASK ||--o{ API_KEY : "owns"
-    IDP_IDENTITY ||--|| USER : "EXTERNAL identity"
-    IDP_IDENTITY ||--|| TOKEN : "delegated authentication"
-
-    USER {
-        uint id PK
-        string userid "unique"
-        string password "encrypted"
-        string email "unique"
-    }
-
-    ROLE {
-        uint id PK
-        string name "unique"
-    }
-
-    PERMISSION {
-        uint id PK
-        string name "human readable name"
-        string scope "scope"
-    }
-
-    API_KEY {
-        uint id PK
-        uint user_id FK
-        uint task_id FK
-        string digest "unique, hashed-secret"
-        datetime expiration
-    }
-
-    IDP_IDENTITY {
-        uint id PK
-        uint user_id FK
-        string provider "Ex: google"
-        string subject
-        string refresh_token "(encrypted)"
-        datetime expiration
-        datetime last_authenticated
-        datetime last_refreshed
-    }
-    
-    TOKEN {
-        uint id PK
-        uint user_id FK
-        uint idp_identity_id FK "0 = none"
-        string jti "jwt id"
-        datetime expiration
-    }
-    
-    TASK {
-    uint id PK
-    }
-```
-
-#### Notes:
-- The Token table contains hub issued tokens.
-- The Token._expiration_ column is mainly used for reaping.
-- API-Key stored in the DB but cached in memory for performance and mitigate DB pressure.
-
-### Login
-
-```mermaid
-sequenceDiagram
-    participant UI as UI (Client Application)
-    participant Hub as Hub Provider<br>(OIDC Provider)
-    participant User as User
-    participant DB as Database<br>(Users + Roles)
-
-    Note over UI,Hub: Local Authorization Code Flow (No Consent)
-
-    UI->>Hub: GET /oauth2/authorize<br>?client_id=...&scope=openid profile email
-    activate Hub
-
-    Hub->>User: Redirect to Login Page
-    User->>Hub: Shows Login Form
-
-    User->>Hub: POST login credentials<br>(username + password)
-    activate Hub
-
-    Hub->>DB: Authenticate User<br>(check username + password)
-    DB-->>Hub: User record + associated Roles
-
-    alt Invalid Credentials
-        Hub->>User: Show Login Page with Error
-        deactivate Hub
-    else Valid Credentials
-        Hub->>Hub: Set Subject (username)
-
-        Hub->>DB: Get User Roles & Scopes
-        DB-->>Hub: List of scopes from roles
-
-        Hub->>Hub: Apply Authorization Layer<br>(merge requested scopes + role-based scopes)
-
-        Hub-->>UI: Redirect back with authorization code
-        deactivate Hub
-    end
-
-    Note over UI,Hub: Back-channel token exchange
-
-    UI->>Hub: POST /oauth2/token<br>grant_type=authorization_code + code_verifier
-    activate Hub
-
-    Hub-->>UI: Access Token + ID Token + Refresh Token<br>(signed by Hub keys, containing role-based scopes)
-
-    deactivate Hub
-
-    Note over UI: UI now has tokens issued by Hub Provider<br>with local user identity + authorization from roles
-```
-
-### Login (external Idp)
-
-when and external provider is configured, the login page rendered by the hub will contain a
-button for this.  For example: "Login with Google".
-
-```mermaid
-sequenceDiagram
-    participant UI as UI (Client Application)
-    participant Hub as Hub <br>(OIDC Broker)
-    participant ExternalIdP as External IdP<br>(e.g. Google)
-    participant User as User
-    participant DB as Database<br>(Users + Roles)
-
-    Note over UI,Hub: Authorization Code Flow starts
-
-    UI->>Hub: GET /oauth2/authorize<br>?client_id=...&scope=...&idp=google
-    activate Hub
-
-    Hub->>User: Redirect to External Login<br>(or show IdP selector)
-    User->>ExternalIdP: Browser redirects to Google login page
-    activate ExternalIdP
-
-    ExternalIdP->>User: Show Google login / consent screen
-    User->>ExternalIdP: Authenticates (username/password or SSO)
-
-    ExternalIdP-->>User: Redirect back to Hub Provider<br>with authorization code
-    deactivate ExternalIdP
-
-    User->>Hub: Callback with code<br>(/oauth2/authorize/{callback_id}?code=...)
-
-    Hub->>ExternalIdP: POST /token (exchange code)
-    activate ExternalIdP
-    ExternalIdP-->>Hub: ID Token + Access Token
-    deactivate ExternalIdP
-
-    Hub->>ExternalIdP: GET UserInfo (optional)
-    ExternalIdP-->>Hub: User claims (sub, email, name, ...)
-
-    Hub->>DB: Lookup or Create User<br>(map Google sub/email → local user)
-    activate DB
-    DB-->>Hub: Local user record + associated Roles
-
-    Hub->>Hub: Apply Authorization Layer<br>(add role-based scopes, custom claims)
-    deactivate DB
-
-    alt Consent Required
-        Hub->>User: Show Consent Screen<br>("Allow this app to access ...")
-        User->>Hub: User approves (or denies)
-    else Consent Already Given
-        Note right of Hub: Skip consent
-    end
-
-    Hub-->>UI: Redirect back with authorization code
-    deactivate Hub
-
-    Note over UI,Hub: Back-channel token exchange
-
-    UI->>Hub: POST /oauth2/token<br>grant_type=authorization_code + code_verifier
-    activate Hub
-
-    Hub-->>UI: Access Token + ID Token + Refresh Token<br>(signed by Hub keys, with local scopes/claims)
-
-    deactivate Hub
-
-    Note over UI: UI now has tokens issued by the Hub Provider<br>containing both external identity + local authorization (roles/scopes)
-```
-
-### Login (LDAP | Activity Directory)
-
-TLDR:
-- ODDC (started)
-- Query user using service account.
-- Bind as user. (authentication)
-- Query for group membership.
-- Map groups to roles (and then scopes)
-- OIDC (continued).
-
-
-```mermaid
-sequenceDiagram
-    participant UI as UI / Client
-    participant Hub as Hub Provider (OIDC)
-    participant LDAP as LDAP / Active Directory
-    participant ProtectedAPI as Protected API
-    participant DB as Database
-
-    Note over Hub,LDAP: Authentication uses Search + Bind pattern<br>Group retrieval via memberOf (AD) or group search
-
-    %% === Initial Login Flow (Authorization Code Flow) ===
-    UI->>Hub: GET /authorize (client_id, scope=openid profile email, redirect_uri...)
-    Hub-->>UI: Redirect to Hub Login Page
-
-    UI->>Hub: POST Login (username + password)
-    activate Hub
-
-    Hub->>LDAP: 1. Search for user (by sAMAccountName / uid) → get DN
-    LDAP-->>Hub: User DN + basic attributes
-
-    Hub->>LDAP: 2. Bind as user DN with provided password
-    LDAP-->>Hub: Bind Success / Failure
-
-    alt Authentication Failed
-        Hub-->>UI: Login failed → show error
-    else Authentication Succeeded
-        Hub->>LDAP: 3. Fetch groups (memberOf attribute or group search)
-        LDAP-->>Hub: List of group DNs / CNs (e.g. IT-Admins, Finance-Users...)
-
-        Hub->>Hub: Apply YAML group rules (any/and + glob matching)<br>→ Compute internal roles & scopes
-        Hub->>DB: Create / update local user session (optional: store last groups, roles)
-
-        Hub-->>UI: Redirect back with authorization code
-    end
-
-    deactivate Hub
-
-    UI->>Hub: POST /token (grant_type=authorization_code, code=...)
-    activate Hub
-    Hub->>Hub: Validate code + issue tokens
-    Hub-->>UI: Access Token (JWT with roles/scopes) + ID Token + Refresh Token
-    deactivate Hub
-
-    Note over Hub,DB: Access Token contains pre-computed roles/scopes from LDAP groups
-
-    %% === Subsequent API Requests ===
-    UI->>ProtectedAPI: Request with Hub access_token
-    activate ProtectedAPI
-
-    ProtectedAPI->>ProtectedAPI: Verify Hub JWT signature + claims (roles/scopes)
-    ProtectedAPI->>DB: Optional: Lookup user + session metadata
-
-    alt Re-validation / Group Refresh Enabled
-        ProtectedAPI->>Hub: Optional introspection or /userinfo (or direct LDAP check if designed)
-        Hub->>LDAP: Re-fetch current groups (if needed)
-        Hub->>Hub: Re-apply rules → updated roles
-        Hub-->>ProtectedAPI: Updated claims / decision
-    else Simple Mode (no re-validation)
-        ProtectedAPI->>ProtectedAPI: Check local roles/scopes from token
-    end
-
-    alt Access Allowed
-        ProtectedAPI-->>UI: 200 OK + response
-    else Access Denied
-        ProtectedAPI-->>UI: 403 Forbidden
-    end
-
-    deactivate ProtectedAPI
-```
-
-### Token Validation
-
-```mermaid
-sequenceDiagram
-    participant UI as UI / API Client
-    participant Hub as Hub Provider<br>(OIDC Provider)
-    participant API as REST API
-    participant DB as API Key Database / Store
-
-    Note over UI,ProtectedAPI: Updated Bearer Token Validation Flow<br>(JWT RSA + JWT HMAC deprecated + API Keys)
-
-    UI->>ProtectedAPI: GET /api/projects<br>Authorization: Bearer <token>
-    activate ProtectedAPI
-
-    ProtectedAPI->>ProtectedAPI: 1. Extract Bearer token
-
-    alt Token is a JWT (contains exactly two '.' characters)
-        ProtectedAPI->>ProtectedAPI: 2. Decode JWT Header (read alg)
-
-        alt alg starts with "RS" (RSA)
-            ProtectedAPI->>ProtectedAPI: 3a. Verify RSA Signature using Hub JWKS
-            note right of ProtectedAPI: Recommended
-        else alg starts with "HS" (HMAC)
-            ProtectedAPI->>ProtectedAPI: 3b. Verify HMAC Signature using shared secret
-            note right of ProtectedAPI: Deprecated but supported for backwards compat
-        else Unsupported algorithm
-            ProtectedAPI-->>UI: 401 Unauthorized
-            note right of ProtectedAPI: Reject unknown algs including "none"
-        end
-
-        ProtectedAPI->>ProtectedAPI: 4. Validate Standard JWT Claims (iss, aud, exp, etc.)
-        ProtectedAPI->>ProtectedAPI: 5. Extract Claims (sub, scope, roles...)
-
-    else Token is NOT a valid JWT → Treat as API Key
-        ProtectedAPI->>DB: 2b. Lookup API Key in DB
-        activate DB
-        DB-->>ProtectedAPI: Key record (active?, scopes/permissions)
-        deactivate DB
-
-        alt API Key invalid or revoked
-            ProtectedAPI-->>UI: 401 Unauthorized
-        else API Key valid
-            ProtectedAPI->>ProtectedAPI: 3c. Map DB permissions to scopes
-        end
-    end
-
-    alt Token validation failed
-        ProtectedAPI-->>UI: 401 Unauthorized
-    else Token is valid
-        ProtectedAPI->>ProtectedAPI: 6. Perform Authorization Check<br>(unified scope check)
-        alt Authorization fails
-            ProtectedAPI-->>UI: 403 Forbidden
-        else Authorization passed
-            ProtectedAPI-->>UI: 200 OK + Response
-        end
-    end
-
-    deactivate ProtectedAPI
-
-    Note over ProtectedAPI: Key Notes<br/>RSA via JWKS is strongly preferred.<br/>HMAC is deprecated but honored for backwards compatibility.<br/>API Keys are mapped to the same scope model as JWTs.<br/>Always reject alg="none" and unknown algorithms.<br/>Consider logging HMAC usage for migration tracking.
-```
-
-### Token validation (external Idp)
-
-```mermaid
-sequenceDiagram
-    participant UI as UI / Client
-    participant Hub as Hub Provider
-    participant ProtectedAPI as Protected API
-    participant DB as Database
-    participant ExternalIdP as External IdP (Google, etc.)
-
-    Note over Hub,DB: During initial login: Store external refresh_token linked to local user
-
-    UI->>ProtectedAPI: Request with Hub access_token
-    activate ProtectedAPI
-
-    ProtectedAPI->>ProtectedAPI: Verify Hub JWT signature + claims
-    ProtectedAPI->>DB: Lookup user + stored external refresh_token
-
-    alt Re-validation Enabled
-        ProtectedAPI->>ExternalIdP: Attempt refresh<br>(POST /token with refresh_token)
-        ExternalIdP-->>ProtectedAPI: Success → new external tokens<br>OR Failure (invalid_grant / revoked)
-        
-        alt External Refresh Failed (Revoked)
-            ProtectedAPI->>ProtectedAPI: Mark session as invalid / force re-login
-            ProtectedAPI-->>UI: 401 Unauthorized + prompt to re-authenticate
-        else External Refresh Succeeded
-            ProtectedAPI->>ProtectedAPI: Optional: Update stored tokens
-            ProtectedAPI->>ProtectedAPI: Check local roles/scopes
-            ProtectedAPI-->>UI: 200 OK
-        end
-    else No Re-validation (simple mode)
-        ProtectedAPI-->>UI: 200 OK (until Hub token expires)
-    end
-
-    deactivate ProtectedAPI
-```
-
-#### Policy
-
-The role mapping policy can be expressed and edited by the UI as simple YAML. This policy maps LDAP/Active Directory 
-group memberships to internal roles, which in turn define the user's permissions (scopes).
-
-**Schema:**
-- Each mapping rule contains a conditional expression (`any` or `and`) and a list of `roles` to assign
-- **`any`**: User matches if they belong to **at least one** of the listed groups (logical OR)
-- **`and`**: User matches if they belong to **all** of the listed groups (logical AND)
-- **`roles`**: List of internal role names to assign when the condition matches
-
-**Evaluation:**
-- All rules are evaluated for each user during authentication
-- A user may match multiple rules and accumulate roles from all matches
-- The final set of permissions (scopes) is derived from the union of all assigned roles
-- Group names are matched exactly (case-sensitive) against the groups returned from LDAP/AD
-
-**Example policy:**
-
-```yaml
-groups:
-  # Administrators
-  - any:
-      - Engineering-Admins
-      - Platform-Admins
-      - IT-Admins
-      - SEC-Global-Admins
-      - Infrastructure-Admins
-    roles:
-      - admin
-
-  # Managers
-  - and:
-      - Engineering
-      - Engineering-Managers
-      - Managers
-    roles:
-      - manager
-
-  # Architects
-  - any:
-      - Engineering-Architects
-      - Principal-Architects
-      - Solution-Architects
-      - Tech-Leads
-    roles:
-      - architect
-
-  # Migrators
-  - any:
-      - Engineering-Migration-Team
-      - Database-Admins
-      - SRE-Migration
-      - Platform-Migration
-      - Data-Migration-Team
-    roles:
-      - migrator
-
-  # High-privilege production access
-  - and:
-      - Engineering
-      - Prod-Admins
-    roles:
-      - admin
-      - migrator
-```
+See [DESIGN.md](./DESIGN.md) for complete technical specifications including:
+- API endpoints and routes
+- Data model and entity relationships
+- Authentication flow diagrams (local, external OIDC, LDAP/AD)
+- Token validation sequences
+- API key implementation details
+- LDAP/AD group mapping policy schemas and examples
 
 ### Test Plan
 
-- Add hub binding tests for User, Role resources.
-- Add authz tests using OIDC client.
-- TBD
+**Unit Testing:**
+- Hub model bindings for User, Role, Permission, Token, APIKey, and IdpIdentity resources
+- API key generation, validation, and revocation logic
+- Token issuance and validation logic
+- Group-to-role mapping policy evaluation
+
+**Integration Testing:**
+- OIDC authorization code flow with local authentication
+- OIDC delegation to external providers (using test IdP)
+- LDAP/AD authentication and group mapping (using test LDAP server)
+- API key authentication and authorization
+- Token refresh and revocation
+- UI authentication flows using the Hub OIDC provider
+
+**End-to-End Testing:**
+- Complete user workflows: login, access protected resources, logout
+- Role and permission management through the UI
+- API key creation and usage for programmatic access
+- External provider integration scenarios
 
 ### Upgrade / Downgrade Strategy
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -145,15 +145,15 @@ Resources:
 
 Standard OIDC endpoints:
 
-| Method | Path                                | Purpose                                                                                        |
-|--------|-------------------------------------|------------------------------------------------------------------------------------------------|
-| GET    | `/.well-known/openid-configuration` | Discovery document – Tells clients all the endpoints, supported scopes, grant types, etc.      |
-| GET    | `/oidc/authorize`                   | Authorization Endpoint – Starts the login flow (shows login form or redirects to external IdP) |
-| POST   | `/oidc/token`                       | Token Endpoint – Exchanges authorization code for access_token + id_token + refresh_token      |
-| GET    | `/oidc/jwks`                        | JSON Web Key Set – Public keys used by clients to verify your JWT signatures                   |
-| GET    | `/oidc/userinfo`                    | UserInfo Endpoint – Returns user claims (optional, but commonly used)                          |
-| POST   | `/oidc/introspect`                  | Token Introspection – Allows resource servers to validate opaque tokens (optional)             |
-| POST   | `/oidc/revoke`                      | Token Revocation – Allows clients to revoke refresh tokens (optional but recommended)          |
+| Method | Path                              | Purpose                                                                                        |
+|--------|-----------------------------------|------------------------------------------------------------------------------------------------|
+| GET    | /.well-known/openid-configuration | Discovery document – Tells clients all the endpoints, supported scopes, grant types, etc.      |
+| GET    | /oidc/authorize                   | Authorization Endpoint – Starts the login flow (shows login form or redirects to external IdP) |
+| POST   | /oidc/token                       | Token Endpoint – Exchanges authorization code for access_token + id_token + refresh_token      |
+| GET    | /oidc/jwks                        | JSON Web Key Set – Public keys used by clients to verify your JWT signatures                   |
+| GET    | /oidc/userinfo                    | UserInfo Endpoint – Returns user claims (optional, but commonly used)                          |
+| POST   | /oidc/introspect                  | Token Introspection – Allows resource servers to validate opaque tokens (optional)             |
+| POST   | /oidc/revoke                      | Token Revocation – Allows clients to revoke refresh tokens (optional but recommended)          |
 
 ### High Level Model:
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -116,7 +116,7 @@ with these tokens.  However, new tasks will be configured to present API-Keys.
 
 ### Revocation
 
-Tokens and API-Keys are revoked by deletion.
+Deletion revokes tokens and API-Keys.
 
 DELETE /auth/tokens/:id
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -123,6 +123,7 @@ erDiagram
 ```
 
 Notes:
+- The Token table contains hub issued tokens.
 - The _expiration_ column is mainly used for reaping.
 
 **Basic** Login:

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -106,6 +106,12 @@ The task manager and addon API will be refactored to use API keys instead of cus
 
 API keys support optional expiration dates and can be explicitly revoked. The keys themselves are not stored in the database—only cryptographic digests—ensuring that compromise of the database does not directly expose API keys.
 
+#### Integration
+
+Client tools such as KAI and Kantra will obtain an API-Key by posting to the API-Key endpoint.  The
+request body will include the userid, password and _optional_ lifespan (minutes). For Go clients
+such as Kantra, this will behave much like the current token-based authentication.
+
 #### Task-Scoped Authentication
 
 API keys can be associated with either users or individual tasks. This enables task-specific authentication where a running task (such as an analysis addon) has exactly the permissions it needs for its operation, independent of the user who initiated it. This separation improves security by limiting the blast radius of compromised credentials and enables better audit trails for automated operations.
@@ -117,7 +123,7 @@ API keys can be associated with either users or individual tasks. This enables t
 - Token validation supports both RSA-signed JWTs (via JWKS) and API keys
 - HMAC-signed tokens are deprecated but maintained for backwards compatibility
 - Tokens and API keys can be explicitly revoked with immediate (API keys) or deferred (tokens on next refresh) effect
-- OIDC clients are configured via operator-managed ConfigMaps rather than stored in the database
+- OIDC clients are configured via operator-managed Secrets rather than stored in the database
 
 #### External Provider Integration
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -74,7 +74,7 @@ reports no vulnerabilities or backdoors.
 
 ### Routes/Endpoints
 
-OIDC Endpoints Provided by `go-oidc`
+OIDC _standard_ endpoints Provided by `go-oidc`
 
 | Method | Endpoint Path                       | Purpose |
 |--------|-------------------------------------|---------|

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -351,35 +351,19 @@ enabled (`AUTH_REQUIRED=true`), it will:
 
 2. **Update the OIDC configuration Secret** (`hub-oidc`) to include Keycloak as an external IdP in the `idp:` section:
    ```yaml
-   apiVersion: v1
-   kind: Secret
-   metadata:
-     name: hub-oidc
-     namespace: konveyor-tackle
-   type: Opaque
-   stringData:
-     oidc.yaml: |
-       clients:
-         - clientId: konveyor-ui
-           clientSecret: <ui-client-secret>
-           redirectURIs:
-             - https://ui.konveyor.io/auth/callback
-           scopes:
-             - openid
-             - profile
-             - email
-       
-       idp:
-         - kind: oidc
-           name: keycloak
-           issuer: "https://keycloak.example.com/realms/konveyor"
-           clientId: "tackle-hub"
-           clientSecret: "<keycloak-client-secret>"
-           scopes:
-             - openid
-             - profile
-             - email
+   idp:
+     - kind: oidc
+       name: keycloak
+       issuer: "https://keycloak.example.com/realms/konveyor"
+       clientId: "tackle-hub"
+       clientSecret: "<keycloak-client-secret>"
+       scopes:
+         - openid
+         - profile
+         - email
    ```
+   
+   See the "OIDC Configuration Secret" section above for the complete Secret structure.
 
 3. **Update Hub deployment** to:
    - Remove Keycloak-specific environment variables

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -29,7 +29,12 @@ Add builtin AuthN and AuthZ functionality so that KeyCloak is no longer required
 
 ## Summary
 
-Currently, Keycloak is required to provide user authentication and authorization. Both the Hub and the UI integrate with Keycloak using Keycloak clients. The goal is to convert to OIDC (OpenID Connect) for authentication and authorization integration and remove the dependence on Keycloak. This will be achieved by providing an internal OIDC provider within the Hub, with optional delegation to external OIDC providers (such as Keycloak, Google, Okta, or others).
+Currently, Keycloak is required to provide user authentication and authorization.
+Both the Hub and the UI integrate with Keycloak using Keycloak clients. The goal
+is to convert to OIDC (OpenID Connect) for authentication and authorization
+integration and remove the dependence on Keycloak. This will be achieved by
+providing an internal OIDC provider within the Hub, with optional delegation to
+external OIDC providers (such as Keycloak, Google, Okta, or others).
 
 ## Motivation
 
@@ -43,127 +48,224 @@ Eliminate dependence on Keycloak.
 - To delegate AuthN, AuthZ to an _external_ OIDC provider. (option)
 - To delegate AuthN, AuthZ to an _external_ LDAP, Active Directory with group mapping. (option)
 - To provide RBAC (users, roles, permissions) management in the inventory.
-- To provide for API-Key authentication.  An API-Key is a generated secret used for application integration.
-- To support explicit revocation of both access tokens and API keys for immediate credential invalidation.
+- To provide for API-Key authentication.  An API-Key is a generated secret used
+  for application integration.
+- To support explicit revocation of both access tokens and API keys for
+  immediate credential invalidation.
 
 ### Non-Goals
 
 ## Proposal
 
-This proposal transforms the Hub into an OIDC-compliant identity provider, eliminating the hard dependency on Keycloak while providing flexible authentication options.
+This proposal transforms the Hub into an OIDC-compliant identity provider,
+eliminating the hard dependency on Keycloak while providing flexible
+authentication options.
 
 ### User Stories
 
-**As a cluster administrator**, I want to deploy Konveyor without requiring Keycloak, so that I can reduce infrastructure complexity and resource overhead.
+**As a cluster administrator**, I want to deploy Konveyor without requiring
+Keycloak, so that I can reduce infrastructure complexity and resource overhead.
 
-**As a security administrator**, I want to integrate Konveyor with my organization's existing identity provider (OIDC, LDAP, or Active Directory), so that I can enforce centralized authentication policies and maintain a single source of truth for user identities.
+**As a security administrator**, I want to integrate Konveyor with my
+organization's existing identity provider (OIDC, LDAP, or Active Directory), so
+that I can enforce centralized authentication policies and maintain a single
+source of truth for user identities.
 
-**As a developer**, I want to use API keys for programmatic access to Konveyor APIs, so that I can build automated integrations without managing user credentials.
+**As a developer**, I want to use API keys for programmatic access to Konveyor
+APIs, so that I can build automated integrations without managing user
+credentials.
 
-**As a Hub administrator**, I want to manage users, roles, and permissions directly within the Hub UI, so that I can control access without needing to configure external identity systems for simple deployments.
+**As an administrator**, I want to manage users, roles, and permissions directly
+within the Hub UI, so that I can control access without needing to configure
+external identity systems for simple deployments.
 
 ### High-Level Approach
 
 #### OIDC Provider
 
-The Hub will implement a standards-compliant OIDC provider supporting the authorization code flow with PKCE. This provider can operate in several modes:
+The Hub will implement a standards-compliant OIDC provider supporting the
+authorization code flow with PKCE. This provider can operate in several modes:
 
-1. **Self-contained mode**: Users, roles, and permissions are managed entirely within the Hub's inventory. Authentication uses locally stored credentials.
+1. **Self-contained mode**: Users, roles, and permissions are managed entirely
+   within the Hub's inventory. Authentication uses locally stored credentials.
 
-2. **External OIDC delegation**: The Hub acts as an OIDC broker, delegating authentication to external providers (Google, Keycloak, Okta, etc.) while maintaining local authorization (role and permission management). This allows organizations to leverage existing identity providers while keeping fine-grained access control within Konveyor.
+2. **External OIDC delegation**: The Hub acts as an OIDC broker, delegating
+   authentication to external providers (Google, Keycloak, Okta, etc.) while
+   maintaining local authorization (role and permission management). This allows
+   organizations to leverage existing identity providers while keeping
+   fine-grained access control within Konveyor.
 
-3. **LDAP/Active Directory integration**: The Hub authenticates users against LDAP or Active Directory using the standard bind pattern, queries group memberships, and maps groups to local roles using configurable YAML-based rules.
+3. **LDAP/Active Directory integration**: The Hub authenticates users against
+   LDAP or Active Directory using the standard bind pattern, queries group
+   memberships, and maps groups to local roles using configurable YAML-based
+   rules.
 
-The Hub inventory will be extended with new entities for users, roles, permissions, tokens, API keys, and external identity mappings. Users are assigned to roles, and roles are associated with permissions (represented as OAuth scopes).
+The Hub inventory will be extended with new entities for users, roles,
+permissions, tokens, API keys, and external identity mappings. Users are
+assigned to roles, and roles are associated with permissions (represented as
+OAuth scopes).
 
-The UI will be refactored to use OIDC for authentication (replacing the current Keycloak client integration) and will include new pages for managing users, roles, and permissions. The login page will be served from a ConfigMap managed by the operator, enabling branding customization without code changes.
+The UI will be refactored to use OIDC for authentication (replacing the current
+Keycloak client integration) and will include new pages for managing users,
+roles, and permissions. The login page will be served from a ConfigMap managed
+by the operator, enabling branding customization without code changes.
 
-All standard OIDC discovery endpoints will be implemented (`.well-known/openid-configuration`, authorization, token, JWKS, userinfo, introspection, and revocation), allowing any OIDC-compliant client to integrate with the Hub.
+All standard OIDC discovery endpoints will be implemented
+(`.well-known/openid-configuration`, authorization, token, JWKS, userinfo,
+introspection, and revocation), allowing any OIDC-compliant client to integrate
+with the Hub.
 
 #### Default Role Definitions
 
-The system will include predefined roles tailored to common migration project personas (administrators, architects, project managers, migration specialists). These default roles provide sensible permission defaults out-of-the-box and are immutable—they cannot be modified or deleted. Organizations can use these as-is for quick deployments or create custom roles with different permission combinations to match their specific governance requirements.
+The system will include predefined roles tailored to common migration project
+personas (administrators, architects, project managers, migration specialists).
+These default roles provide sensible permission defaults out-of-the-box and are
+immutable—they cannot be modified or deleted. Organizations can use these as-is
+for quick deployments or create custom roles with different permission
+combinations to match their specific governance requirements.
 
 #### Flexible Role and Permission Management
 
-The system provides a fixed catalog of permissions that map to specific API operations and resources. This permission catalog is immutable—permissions cannot be added, modified, or deleted at runtime. This ensures consistent authorization semantics across deployments and simplifies security auditing.
+The system provides a fixed catalog of permissions that map to specific API
+operations and resources. This permission catalog is immutable—permissions
+cannot be added, modified, or deleted at runtime. This ensures consistent
+authorization semantics across deployments and simplifies security auditing.
 
-Custom role definitions support multiple management approaches to accommodate different operational models:
-- **Operator-managed**: Custom roles can be defined in configuration files and deployed consistently across environments
-- **UI-managed**: Administrators can create, modify, and delete custom roles through the web interface, selecting from the available permission catalog
-- **Hybrid**: Organizations can seed custom roles via configuration while allowing runtime customization through the UI
+Custom role definitions support multiple management approaches to accommodate
+different operational models:
+- **Operator-managed**: Custom roles can be defined in configuration files and
+  deployed consistently across environments
+- **UI-managed**: Administrators can create, modify, and delete custom roles
+  through the web interface, selecting from the available permission catalog
+- **Hybrid**: Organizations can seed custom roles via configuration while
+  allowing runtime customization through the UI
 
-Default roles (admin, architect, manager, migrator) are immutable and cannot be modified or deleted. Organizations needing different permission combinations should create custom roles using the available permissions.
+Default roles (admin, architect, manager, migrator) are immutable and cannot be
+modified or deleted. Organizations needing different permission combinations
+should create custom roles using the available permissions.
 
-This approach enables both centralized governance (via operator control and immutable defaults) and decentralized administration (via UI self-service for custom roles).
+This approach enables both centralized governance (via operator control and
+immutable defaults) and decentralized administration (via UI self-service for
+custom roles).
 
 #### Resource-Based Authorization Model
 
-Authorization is enforced using a resource-and-action permission model. Permissions define what actions (create, read, update, delete) can be performed on which resources (applications, assessments, tasks, etc.). This maps naturally to REST API operations and provides fine-grained access control without requiring administrators to understand OAuth scope syntax.
+Authorization is enforced using a resource-and-action permission model.
+Permissions define what actions (create, read, update, delete) can be performed
+on which resources (applications, assessments, tasks, etc.). This maps naturally
+to REST API operations and provides fine-grained access control without
+requiring administrators to understand OAuth scope syntax.
 
-Permissions can be scoped broadly (all operations on a resource) or narrowly (specific operations on specific sub-resources), supporting both simple and complex authorization requirements.
+Permissions can be scoped broadly (all operations on a resource) or narrowly
+(specific operations on specific sub-resources), supporting both simple and
+complex authorization requirements.
 
 #### API Key Authentication
 
-API keys provide a secure mechanism for programmatic access, addressing [RFE-266](https://github.com/konveyor/enhancements/issues/266). Users can generate API keys through the Hub API, which inherit the user's permissions at the time of creation. Keys are presented as Bearer tokens and validated using the same scope-based authorization model as JWT tokens.
+API keys provide a secure mechanism for programmatic access, addressing
+[RFE-266](https://github.com/konveyor/enhancements/issues/266). Users can
+generate API keys through the Hub API, which inherit the user's permissions at
+the time of creation. Keys are presented as Bearer tokens and validated using
+the same scope-based authorization model as JWT tokens.
 
-The task manager and addon API will be refactored to use API keys instead of custom HMAC-signed JWTs. For backwards compatibility, existing HMAC tokens will continue to be honored for in-flight tasks.
+The task manager and addon API will be refactored to use API keys instead of
+custom HMAC-signed JWTs. For backwards compatibility, existing HMAC tokens will
+continue to be honored for in-flight tasks.
 
-API keys support optional expiration dates and can be explicitly revoked through the Hub API. The keys themselves are not stored in the database—only cryptographic digests—ensuring that compromise of the database does not directly expose API keys.
+API keys support optional expiration dates and can be explicitly revoked through
+the Hub API. The keys themselves are not stored in the database—only
+cryptographic digests—ensuring that compromise of the database does not directly
+expose API keys.
 
 #### Tools Integration
 
-Client tools such as **Kantra** and **KAI** should authenticate by getting an API-Key.  This is almost exactly like the current
-process of getting a (JWT) token (POST `/auth/login`), the client will POST to a new endpoint that instead returns an API-Key.
-The returned key is specified in future requests using authentication header: `Authorization Bearer <key>`.
+Client tools such as **Kantra** and **KAI** should authenticate by getting an
+API-Key.  This is almost exactly like the current process of getting a (JWT)
+token (POST `/auth/login`), the client will POST to a new endpoint that instead
+returns an API-Key. The returned key is specified in future requests using
+authentication header: `Authorization Bearer <key>`.
 
 #### Task-Scoped Authentication
 
-API keys can be associated with either users or individual tasks. This enables task-specific authentication where a running task (such as an analysis addon) has exactly the permissions it needs for its operation, independent of the user who initiated it. This separation improves security by limiting the blast radius of compromised credentials and enables better audit trails for automated operations.
+API keys can be associated with either users or individual tasks. This enables
+task-specific authentication where a running task (such as an analysis addon)
+has exactly the permissions it needs for its operation, independent of the user
+who initiated it. This separation improves security by limiting the blast radius
+of compromised credentials and enables better audit trails for automated
+operations.
 
 #### Credential Lifecycle and Revocation
 
-Both access tokens and API keys support explicit revocation to enable immediate response to security incidents or access changes:
+Both access tokens and API keys support explicit revocation to enable immediate
+response to security incidents or access changes:
 
-- **API Key Revocation**: API keys can be revoked immediately through the Hub API (`DELETE /auth/apikeys/:id`). Revoked keys are rejected instantly on the next authentication attempt, ensuring compromised keys cannot be used.
+- **API Key Revocation**: API keys can be revoked immediately through the Hub
+  API (`DELETE /auth/apikeys/:id`). Revoked keys are rejected instantly on the
+  next authentication attempt, ensuring compromised keys cannot be used.
 
-- **Token Revocation**: Access tokens issued via OIDC flows can be revoked through the Hub API (`DELETE /auth/tokens/:id`). Token revocation takes effect on the next token refresh or when the current access token expires, following standard OIDC patterns. Refresh tokens can also be revoked to prevent re-authentication.
+- **Token Revocation**: Access tokens issued via OIDC flows can be revoked
+  through the Hub API (`DELETE /auth/tokens/:id`). Token revocation takes effect
+  on the next token refresh or when the current access token expires, following
+  standard OIDC patterns. Refresh tokens can also be revoked to prevent
+  re-authentication.
 
-- **Automatic Expiration**: Both tokens and API keys support configurable expiration dates. Expired credentials are automatically rejected without requiring explicit revocation.
+- **Automatic Expiration**: Both tokens and API keys support configurable
+  expiration dates. Expired credentials are automatically rejected without
+  requiring explicit revocation.
 
-This dual-mechanism approach ensures that administrators can quickly respond to security events (compromised credentials, employee departure, role changes) while maintaining compatibility with OIDC client expectations.
+This dual-mechanism approach ensures that administrators can quickly respond to
+security events (compromised credentials, employee departure, role changes)
+while maintaining compatibility with OIDC client expectations.
 
 #### Security Considerations
 
-- All sensitive data will be stored securely: passwords as bcrypt hashes, refresh tokens encrypted
+- All sensitive data will be stored securely: passwords as bcrypt hashes,
+  refresh tokens encrypted
 - API keys are stored as hashed digests, never in plain text
 - Token validation supports both RSA-signed JWTs (via JWKS) and API keys
 - HMAC-signed tokens are deprecated but maintained for backwards compatibility
-- Tokens and API keys can be explicitly revoked with immediate (API keys) or deferred (tokens on next refresh) effect
-- OIDC clients are configured via operator-managed Secrets rather than stored in the database
+- Tokens and API keys can be explicitly revoked with immediate (API keys) or
+  deferred (tokens on next refresh) effect
+- OIDC clients are configured via operator-managed Secrets rather than stored in
+  the database
 
 #### External Provider Integration
 
-When configured with external providers, the Hub stores refresh tokens (encrypted) to enable ongoing validation. For LDAP/AD integrations, group-to-role mapping is expressed as simple YAML rules supporting both "any" (OR) and "and" (AND) logic, allowing flexible policy definition without code changes.
+When configured with external providers, the Hub stores refresh tokens
+(encrypted) to enable ongoing validation. For LDAP/AD integrations,
+group-to-role mapping is expressed as simple YAML rules supporting both "any"
+(OR) and "and" (AND) logic, allowing flexible policy definition without code
+changes.
 
-A README will be published documenting the expected roles and permission scopes catalog to support administrators who want to configure external OIDC providers or Keycloak realms to work with the Hub.
+A README will be published documenting the expected roles and permission scopes
+catalog to support administrators who want to configure external OIDC providers
+or Keycloak realms to work with the Hub.
 
 #### Development and Testing Support
 
-The authentication system supports a development mode where authentication can be disabled entirely, simplifying local development and automated testing scenarios. This mode is controlled by configuration and clearly separated from the production authentication path to prevent accidental deployment with authentication disabled.
+The authentication system supports a development mode where authentication can
+be disabled entirely, simplifying local development and automated testing
+scenarios. This mode is controlled by configuration and clearly separated from
+the production authentication path to prevent accidental deployment with
+authentication disabled.
 
 #### Operational Flexibility
 
-The system is designed to adapt to different organizational requirements without architectural changes. Deployments can start simple with local authentication and evolve to integrate with enterprise identity providers as needs change, without requiring migration or re-architecture.
+The system is designed to adapt to different organizational requirements without
+architectural changes. Deployments can start simple with local authentication
+and evolve to integrate with enterprise identity providers as needs change,
+without requiring migration or re-architecture.
 
 ### Security, Risks, and Mitigations
 
-The [go-oidc](https://github.com/luikyv/go-oidc) package is **OpenID certified** and is actively maintained. It has no reported CVEs.  AI code analysis
-reports no vulnerabilities or backdoors.
+Both the [go-oidc](https://github.com/luikyv/go-oidc) and [oidc](https://github.com/zitadel/oidc)
+packages are **OpenID certified** and are actively maintained. They have no 
+reported CVEs.  AI code analysis reports no vulnerabilities or backdoors.
 
 ## Design Details
 
-See [DESIGN.md](./DESIGN.md) for complete technical specifications (for illustration not approval) including:
+See [DESIGN.md](./DESIGN.md) for complete technical specifications (for
+illustration not approval) including:
 - API endpoints and routes
 - Data model and entity relationships
 - Authentication flow diagrams (local, external OIDC, LDAP/AD)

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -56,8 +56,9 @@ Eliminate dependence on Keycloak.
 Make the hub an OIDC provider. The provider policy may be self-contained or configured
 to delegate authentication and/or authorization to an external provider. The hub inventory
 is augmented to include Users and Roles. Users may be associated to roles and roles may
-be associated to permissions (scopes).  Tokens will continue to contain scope claims.
+be associated to permissions (scopes).
 
+High Level Model:
 
 ```mermaid
 erDiagram
@@ -94,7 +95,7 @@ erDiagram
     }
 ```
 
-Login:
+**Basic** Login:
 
 ```mermaid
 sequenceDiagram
@@ -144,7 +145,7 @@ sequenceDiagram
     Note over UI: UI now has tokens issued by Hub Provider<br>with local user identity + authorization from roles
 ```
 
-Login when and external provider is configured, the login page rendered by the hub will contain a
+**Login** when and external provider is configured, the login page rendered by the hub will contain a
 button for this.  For example: "Login with Google".
 
 ```mermaid
@@ -209,7 +210,7 @@ sequenceDiagram
     Note over UI: UI now has tokens issued by the Hub Provider<br>containing both external identity + local authorization (roles/scopes)
 ```
 
-Token validation:
+Token **Validation**:
 
 ```mermaid
 sequenceDiagram
@@ -249,7 +250,7 @@ sequenceDiagram
     Note over ProtectedAPI: Common Validation Order:<br>1. Signature + Issuer<br>2. Expiration<br>3. Audience<br>4. Scopes / Claims<br>5. Custom business rules
 ```
 
-Token validation with external provider:
+Token **validation** with external provider:
 
 ```mermaid
 sequenceDiagram

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -61,15 +61,20 @@ be associated to permissions (scopes).
 The UI will be updated to use OIDC (instead of keycloak) and be configured to use the
 hub OIDC provider.  The UI will have pages to manage user, roles and permissions.
 
-The Tackle CR will support configuring the hub to use an external OIDC provider but it will no longer install,
-configure or seed it.  The installation and configuration of an external provider is the sole responsibility 
-of the user.
-
 The UI fragment used for the login page will be read from a ConfigMap managed by the operator.  Branding
 customizations will be handled by the operator.
 
+The hub may be configured to integrate with external (remote) auth providers. The primary mechanism will be OIDC but will
+also support LDAP.  In both cases, scopes (OIDC) and groups (LDAP) may need to be mapped to tackle roles. External
+providers may be created, updated and deleted using the UI/API. Configuration includes connection information
+credentials and mapping information.
+
 Publish a README.md that contains expected roles and a catalog of scopes to support user's bringing their
 own external OIDC provider. This _may_ also include a recommended keycloak Realm specification.
+
+All sensitive information will be stored encrypted.
+
+Access tokens may be revoked (effective next refresh).
 
 ### Security, Risks, and Mitigations
 
@@ -86,11 +91,11 @@ Standard OIDC endpoints Provided by `go-oidc`
 |--------|-------------------------------------|---------|
 | GET    | `/.well-known/openid-configuration` | Discovery document – Tells clients all the endpoints, supported scopes, grant types, etc. |
 | GET    | `/oidc/authorize`                   | Authorization Endpoint – Starts the login flow (shows login form or redirects to external IdP) |
-| POST   | `/oidc/token`                     | Token Endpoint – Exchanges authorization code for access_token + id_token + refresh_token |
-| GET    | `/oidc/jwks`                      | JSON Web Key Set – Public keys used by clients to verify your JWT signatures |
-| GET    | `/oidc/userinfo`                  | UserInfo Endpoint – Returns user claims (optional, but commonly used) |
-| POST   | `/oidc/introspect`                | Token Introspection – Allows resource servers to validate opaque tokens (optional) |
-| POST   | `/oidc/revoke`                    | Token Revocation – Allows clients to revoke refresh tokens (optional but recommended) |
+| POST   | `/oidc/token`                       | Token Endpoint – Exchanges authorization code for access_token + id_token + refresh_token |
+| GET    | `/oidc/jwks`                        | JSON Web Key Set – Public keys used by clients to verify your JWT signatures |
+| GET    | `/oidc/userinfo`                    | UserInfo Endpoint – Returns user claims (optional, but commonly used) |
+| POST   | `/oidc/introspect`                  | Token Introspection – Allows resource servers to validate opaque tokens (optional) |
+| POST   | `/oidc/revoke`                      | Token Revocation – Allows clients to revoke refresh tokens (optional but recommended) |
 
 ### High Level Model:
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -85,10 +85,15 @@ Add support for API-Keys (Reference [RFE-266](https://github.com/konveyor/enhanc
 #### Generation
 POST /auth/apikey returns a 256-bit base64-encoded generated key which has been stored in the DB along with associated
 permissions (scopes).
+Returned:
+```yaml
+ID: uint
+Key: base64-encoded key. (This is the key presented to the API).
+```
 
 #### Revocation
 
-DELETE /auth/apikey/:key
+DELETE /auth/apikey/:id
 
 #### Authentication
 
@@ -178,7 +183,7 @@ erDiagram
 #### Notes:
 - The Token table contains hub issued tokens.
 - The _expiration_ column is mainly used for reaping.
-- API-Key will be stored in the DB but cached in memory for performance and less pressure on the DB.
+- API-Key will be stored (encrypted) in the DB but cached in memory for performance and less pressure on the DB.
 
 ### Login
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -1,5 +1,5 @@
 ---
-title: provide builtin AuthZ
+title: provide-builtin-authz
 authors:
   - "jortel@redhat.com"
 reviewers:

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -79,7 +79,7 @@ erDiagram
     USER }o--o{ ROLE : "granted"
     ROLE }o--o{ PERMISSION : "has"
     IDP_IDENTITY ||--|| USER : "mapped"
-    IDP_IDENTITY ||--|| TOKEN : "mapped"
+    IDP_IDENTITY ||--|| TOKEN : "authenticated by"
 
     USER {
         uint id PK

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -147,7 +147,7 @@ erDiagram
     USER }o--o{ ROLE : "granted"
     ROLE }o--o{ PERMISSION : "has"
     USER ||--o{ API_KEY : "owns"
-    TASK ||--0{ API_KEY : "owns"
+    TASK ||--o{ API_KEY : "owns"
     IDP_IDENTITY ||--|| USER : "EXTERNAL identity"
     IDP_IDENTITY ||--|| TOKEN : "delegated authentication"
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -268,7 +268,7 @@ sequenceDiagram
     Note over UI: UI now has tokens issued by the Hub Provider<br>containing both external identity + local authorization (roles/scopes)
 ```
 
-### LDAP | Activity Directory
+### Login (LDAP | Activity Directory)
 
 TLDR:
 - ODDC (started)

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -46,8 +46,8 @@ Eliminate dependence on Keycloak.
 - To discontinue seeding the realm in keycloak.
 - To support user management in the tackle UI.
   - User CRUD.
-  - Role CRUD
-  - User role assignment.
+  - Role CRUD with association scopes.
+  - Grant roles to users.
 
 ### Non-Goals
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -184,6 +184,9 @@ token (POST `/auth/token`), the client will POST to a new endpoint that instead
 returns a PAT. The returned token is specified in future requests using
 authentication header: `Authorization Bearer <token>`.
 
+The **LLM Proxy** will no longer perform token authentication. Instead, the LLM Proxy servers
+will be proxied behind the hub /services endpoint and delegate auth to the hub.
+
 #### Task-Scoped Authentication
 
 PATs can be associated with either users or individual tasks. This enables

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -47,10 +47,13 @@ Eliminate dependence on Keycloak.
 - To delegate AuthN, AuthZ to an _external_ OIDC provider. (option)
 - To delegate AuthN, AuthZ to an _external_ LDAP, Active Directory with group mapping. (option)
 - To provide RBAC (users, roles, permissions) management in the inventory.
+- To provide for API-Key authentication.  An API-Key is a generated secret used for application integration.
 
 ### Non-Goals
 
 ## Proposal
+
+### OIDC
 
 Make the hub an OIDC provider. The security policy may be self-contained or configured
 to delegate authentication and/or authorization to an external provider. The hub inventory
@@ -74,6 +77,32 @@ own external OIDC provider. This _may_ also include a recommended keycloak Realm
 All sensitive information will be stored encrypted.
 
 Access tokens may be revoked (effective next refresh).
+
+### API Keys
+
+Add support for API-Keys (Reference [RFE-266](https://github.com/konveyor/enhancements/issues/266)).
+
+#### Generation
+POST /auth/apikey returns a 256-bit base64-encoded generated key which has been stored in the DB along with associated
+permissions (scopes).
+
+#### Revocation
+
+DELETE /auth/apikey/:key
+
+#### Authentication
+
+HTTP requests with header: Authentication: Bearer `<key>` is detected and validated:
+1. Find/match stored key.
+2. Get mapped permissions (scopes).
+3. Authorize endpoint access.
+
+#### Addon tokens
+
+Refit task manager and addon API authorization to use API-Key instead of custom JWT token generation.
+For backwards compatibility, Tokens with SigningMethod=HMAC still honored to support in-flight tasks
+with these tokens.  However, new tasks will be configured to present API-Keys.
+
 
 ### Security, Risks, and Mitigations
 
@@ -354,31 +383,60 @@ sequenceDiagram
 sequenceDiagram
     participant UI as UI / API Client
     participant Hub as Hub Provider<br>(OIDC Provider)
-    participant ProtectedAPI as Protected API / Resource Server
+    participant API as REST API
+    participant DB as API Key Database / Store
 
-    Note over UI,ProtectedAPI: Token Validation Flow (most common pattern)
+    Note over UI,ProtectedAPI: Updated Bearer Token Validation Flow<br>(JWT RSA + JWT HMAC deprecated + API Keys)
 
-    UI->>ProtectedAPI: GET /api/projects<br>Authorization: Bearer <access_token>
+    UI->>ProtectedAPI: GET /api/projects<br>Authorization: Bearer <token>
     activate ProtectedAPI
 
-    ProtectedAPI->>ProtectedAPI: 1. Verify JWT Signature<br>(using Hub's JWKS)
-    ProtectedAPI->>ProtectedAPI: 2. Validate Standard Claims<br>(iss, aud, exp, nbf, iat)
+    ProtectedAPI->>ProtectedAPI: 1. Extract Bearer token
 
-    alt Token is Invalid or Expired
+    alt Token is a JWT (contains exactly two '.' characters)
+        ProtectedAPI->>ProtectedAPI: 2. Decode JWT Header (read alg)
+
+        alt alg starts with "RS" (RSA)
+            ProtectedAPI->>ProtectedAPI: 3a. Verify RSA Signature using Hub JWKS
+            note right of ProtectedAPI: Recommended
+        else alg starts with "HS" (HMAC)
+            ProtectedAPI->>ProtectedAPI: 3b. Verify HMAC Signature using shared secret
+            note right of ProtectedAPI: Deprecated but supported for backwards compat
+        else Unsupported algorithm
+            ProtectedAPI-->>UI: 401 Unauthorized
+            note right of ProtectedAPI: Reject unknown algs including "none"
+        end
+
+        ProtectedAPI->>ProtectedAPI: 4. Validate Standard JWT Claims (iss, aud, exp, etc.)
+        ProtectedAPI->>ProtectedAPI: 5. Extract Claims (sub, scope, roles...)
+
+    else Token is NOT a valid JWT → Treat as API Key
+        ProtectedAPI->>DB: 2b. Lookup API Key in DB
+        activate DB
+        DB-->>ProtectedAPI: Key record (active?, scopes/permissions)
+        deactivate DB
+
+        alt API Key invalid or revoked
+            ProtectedAPI-->>UI: 401 Unauthorized
+        else API Key valid
+            ProtectedAPI->>ProtectedAPI: 3c. Map DB permissions to scopes
+        end
+    end
+
+    alt Token validation failed
         ProtectedAPI-->>UI: 401 Unauthorized
-    else Token is Valid
-        ProtectedAPI->>ProtectedAPI: 3. Extract Claims<br>(sub, scope, roles if present)
-        ProtectedAPI->>ProtectedAPI: 4. Check Required Scopes<br>e.g. HasScope("api:read") or role-based check
-        alt Authorization Failed
+    else Token is valid
+        ProtectedAPI->>ProtectedAPI: 6. Perform Authorization Check<br>(unified scope check)
+        alt Authorization fails
             ProtectedAPI-->>UI: 403 Forbidden
-        else Authorization Passed
-            ProtectedAPI-->>UI: 200 OK + Response Data
+        else Authorization passed
+            ProtectedAPI-->>UI: 200 OK + Response
         end
     end
 
     deactivate ProtectedAPI
 
-    Note over ProtectedAPI: Common Validation Order:<br>1. Signature + Issuer<br>2. Expiration<br>3. Audience<br>4. Scopes / Claims<br>5. Custom business rules
+    Note over ProtectedAPI: Key Notes<br/>RSA via JWKS is strongly preferred.<br/>HMAC is deprecated but honored for backwards compatibility.<br/>API Keys are mapped to the same scope model as JWTs.<br/>Always reject alg="none" and unknown algorithms.<br/>Consider logging HMAC usage for migration tracking.
 ```
 
 ### Token validation (external Idp)

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -61,6 +61,10 @@ be associated to permissions (scopes).
 The UI will be updated to use OIDC (instead of keycloak) and be configured to use the
 hub OIDC provider.  The UI will have pages to manage user, roles and permissions.
 
+The Tackle CR will support configuring the hub to use an external OIDC provider but it will no longer install,
+configure or seed it.  The installation and configuration of an external provider is the sole responsibility 
+of the user.
+
 ### Security, Risks, and Mitigations
 
 The [go-oidc](https://github.com/luikyv/go-oidc) package is **OpenID certified** and is actively maintained. It has no reported CVEs.  AI code analysis

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -197,83 +197,18 @@ sequenceDiagram
 The UI will be updated to use OIDC (instead of keycloak) and be configured to use the
 hub OIDC provider.  The UI will have pages to manage user, roles and permissions.
 
-### User Stories [optional]
-
-Detail the things that people will be able to do if this is implemented.
-Include as much detail as possible so that people can understand the "how" of
-the system. The goal here is to make this feel real for users without getting
-bogged down.
-
-#### Story 1
-
-#### Story 2
-
-### Implementation Details/Notes/Constraints [optional]
-
-What are the caveats to the implementation? What are some important details that
-didn't come across above. Go in to as much detail as necessary here. This might
-be a good place to talk about core concepts and how they relate.
-
 ### Security, Risks, and Mitigations
 
-**Carefully think through the security implications for this change**
-
-What are the risks of this proposal and how do we mitigate. Think broadly. How
-will this impact the broader OKD ecosystem? Does this work in a managed services
-environment that has many tenants?
-
-How will security be reviewed and by whom? How will UX be reviewed and by whom?
-
-Consider including folks that also work outside your immediate sub-project.
+The [go-oidc](https://github.com/luikyv/go-oidc) package is **OpenID certified** and is actively maintained. It has no reported CVEs.  AI code analysis
+reports no vulnerabilities or backdoors.
 
 ## Design Details
 
 ### Test Plan
 
-**Note:** *Section not required until targeted at a release.*
-
-Consider the following in developing a test plan for this enhancement:
-- Will there be e2e and integration tests, in addition to unit tests?
-- How will it be tested in isolation vs with other components?
-
-No need to outline all of the test cases, just the general strategy. Anything
-that would count as tricky in the implementation and anything particularly
-challenging to test should be called out.
-
-All code is expected to have adequate tests (eventually with coverage
-expectations).
+- Add hub binding tests for User, Role resources.
+- Add authz tests using OIDC client.
+- TBD
 
 ### Upgrade / Downgrade Strategy
 
-If applicable, how will the component be upgraded and downgraded? Make sure this
-is in the test plan.
-
-Consider the following in developing an upgrade/downgrade strategy for this
-enhancement:
-- What changes (in invocations, configurations, API use, etc.) is an existing
-  cluster required to make on upgrade in order to...
-  -  keep previous behavior?
-  - make use of the enhancement?
-
-## Implementation History
-
-Major milestones in the life cycle of a proposal should be tracked in `Implementation
-History`.
-
-## Drawbacks
-
-The idea is to find the best form of an argument why this enhancement should _not_ be implemented.
-
-## Alternatives
-
-Similar to the `Drawbacks` section the `Alternatives` section is used to
-highlight and record other possible approaches to delivering the value proposed
-by an enhancement.
-
-## Infrastructure Needed [optional]
-
-Use this section if you need things from the project. Examples include a new
-subproject, repos requested, github details, and/or testing infrastructure.
-
-Listing these here allows the community to get the process for these resources
-started right away.

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -78,7 +78,8 @@ High Level Model:
 erDiagram
     USER }o--o{ ROLE : "granted"
     ROLE }o--o{ PERMISSION : "has"
-    TOKEN ||--|| USER : "mapped"
+    IDP_IDENTITY ||--|| USER : "mapped"
+    IDP_IDENTITY ||--|| TOKEN : "mapped"
 
     USER {
         uint id PK
@@ -98,14 +99,31 @@ erDiagram
         string scope "OIDC scope"
     }
     
-    TOKEN {
+    IDP_IDENTITY {
         uint id PK
         uint user_id FK
+        string provider "Ex: google"
+        string subject
+        string refresh_token "(encrypted)"
         datetime expiration
-        string provider "builtin|google|..."
-        string token "refresh token (encrypted)"
+        datetime last_authenticated
+        datetime last_refreshed
+    }
+    
+    TOKEN {
+        uint id PK
+        uint user_id
+        uint idp_identity_id FK
+        string jti "jwt id"
+        datetime expiration
+        datetime revoked
+        datetime last_authenticated
+        datetime last_refreshed
     }
 ```
+
+Notes:
+- The expiration is mainly used for reaping.
 
 **Basic** Login:
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -96,7 +96,7 @@ erDiagram
     PERMISSION {
         uint id PK
         string name "human readable name"
-        string scope "OIDC scope"
+        string scope "scope"
     }
     
     IDP_IDENTITY {
@@ -123,7 +123,7 @@ erDiagram
 ```
 
 Notes:
-- The expiration is mainly used for reaping.
+- The _expiration_ column is mainly used for reaping.
 
 **Basic** Login:
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -79,7 +79,7 @@ erDiagram
     USER }o--o{ ROLE : "granted"
     ROLE }o--o{ PERMISSION : "has"
     IDP_IDENTITY ||--|| USER : "mapped"
-    IDP_IDENTITY ||--|| TOKEN : "authenticated by"
+    IDP_IDENTITY ||--|| TOKEN : "user authenticated by"
 
     USER {
         uint id PK

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -81,16 +81,20 @@ All standard OIDC discovery endpoints will be implemented (`.well-known/openid-c
 
 #### Default Role Definitions
 
-The system will include predefined roles tailored to common migration project personas (administrators, architects, project managers, migration specialists). These roles provide sensible permission defaults out-of-the-box while remaining fully customizable. Organizations can use these as-is for quick deployments or customize them to match their specific governance requirements.
+The system will include predefined roles tailored to common migration project personas (administrators, architects, project managers, migration specialists). These default roles provide sensible permission defaults out-of-the-box and are immutable—they cannot be modified or deleted. Organizations can use these as-is for quick deployments or create custom roles with different permission combinations to match their specific governance requirements.
 
 #### Flexible Role and Permission Management
 
-Role and permission definitions support multiple management approaches to accommodate different operational models:
-- **Operator-managed**: Roles can be defined in configuration files and deployed consistently across environments
-- **UI-managed**: Administrators can create, modify, and delete roles and permissions through the web interface
-- **Hybrid**: Organizations can seed baseline roles via configuration while allowing runtime customization through the UI
+The system provides a fixed catalog of permissions that map to specific API operations and resources. This permission catalog is immutable—permissions cannot be added, modified, or deleted at runtime. This ensures consistent authorization semantics across deployments and simplifies security auditing.
 
-This flexibility enables both centralized governance (via operator control) and decentralized administration (via UI self-service).
+Custom role definitions support multiple management approaches to accommodate different operational models:
+- **Operator-managed**: Custom roles can be defined in configuration files and deployed consistently across environments
+- **UI-managed**: Administrators can create, modify, and delete custom roles through the web interface, selecting from the available permission catalog
+- **Hybrid**: Organizations can seed custom roles via configuration while allowing runtime customization through the UI
+
+Default roles (admin, architect, manager, migrator) are immutable and cannot be modified or deleted. Organizations needing different permission combinations should create custom roles using the available permissions.
+
+This approach enables both centralized governance (via operator control and immutable defaults) and decentralized administration (via UI self-service for custom roles).
 
 #### Resource-Based Authorization Model
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -76,9 +76,8 @@ High Level Model:
 
 ```mermaid
 erDiagram
-    USER ||--o{ USER_ROLE : "has"
-    ROLE ||--o{ ROLE_PERMISSION : "has"
-    PERMISSION ||--o{ ROLE_PERMISSION : "is assigned to"
+    USER ||o-o{ ROLE : "has"
+    ROLE ||o-o{ PERMISSION : "has"
 
     USER {
         uint id PK
@@ -96,16 +95,6 @@ erDiagram
         uint id PK
         string name "human readable name"
         string scope "actual OIDC scope string"
-    }
-
-    USER_ROLE {
-        uint user_id PK,FK
-        uint role_id PK,FK
-    }
-
-    ROLE_PERMISSION {
-        uint role_id PK,FK
-        uint permission_id PK,FK
     }
 ```
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -164,6 +164,8 @@ Entities:
 - Token - issued (valid) tokens. 
 - APIKey - issued (valid) API-Keys.
 
+---
+
 ```mermaid
 erDiagram
     USER }o--o{ ROLE : "granted"

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -116,7 +116,7 @@ with these tokens.  However, new tasks will be configured to present API-Keys.
 
 ### Revocation
 
-Tokens and APIKeys are revoked by deletion.
+Tokens and API-Keys are revoked by deletion.
 
 DELETE /auth/tokens/:id
 
@@ -139,7 +139,7 @@ Resources:
 | ANY           | /auth/roles          | Roles collection               |
 | GET           | /auth/permissions    | Permission collection          |
 | GET \| DELETE | /auth/tokens         | Issued tokens                  |
-| ANY           | /auth/apikeys        | APIKey collection              |
+| ANY           | /auth/apikeys        | API-Key collection             |
 | GET           | /auth/idp/identities | Remote IDP identity collection |
 
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -94,7 +94,7 @@ Returned:
 ```yaml
 id: uint
 expiration: # OPTIONAL
-key: cvP1sjff7_X2dCEIzUPf8f0IzKSbwiSDf1dZChZuRxY # base64URL-encoded key. (This is the key presented to the API).
+key: cvP1sjff7_X2dCEIzUPf8f0IzKSbwiSDf1dZChZuRxY
 ```
 
 #### Revocation

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -65,9 +65,9 @@ The UI fragment used for the login page will be read from a ConfigMap managed by
 customizations will be handled by the operator.
 
 The hub may be configured to integrate with external (remote) auth providers. The primary mechanism will be OIDC but will
-also support LDAP.  In both cases, scopes (OIDC) and groups (LDAP) may need to be mapped to tackle roles. External
+also support LDAP/ActiveDirectory.  In both cases, scopes (OIDC) and groups (LDAP) may need to be mapped to tackle roles. External
 providers may be created, updated and deleted using the UI/API. Configuration includes connection information
-credentials and mapping information.
+credentials and group:role mapping rules. 
 
 Publish a README.md that contains expected roles and a catalog of scopes to support user's bringing their
 own external OIDC provider. This _may_ also include a recommended keycloak Realm specification.
@@ -201,7 +201,7 @@ sequenceDiagram
     Note over UI: UI now has tokens issued by Hub Provider<br>with local user identity + authorization from roles
 ```
 
-### Login (external Authentication)
+### Login (external Idp)
 
 when and external provider is configured, the login page rendered by the hub will contain a
 button for this.  For example: "Login with Google".
@@ -267,6 +267,10 @@ sequenceDiagram
 
     Note over UI: UI now has tokens issued by the Hub Provider<br>containing both external identity + local authorization (roles/scopes)
 ```
+
+### Login (LDAP)
+
+
 
 ### Token Validation
 
@@ -337,6 +341,104 @@ sequenceDiagram
 
     deactivate ProtectedAPI
 ```
+
+### LDAP | Activity Directory
+
+```mermaid
+sequenceDiagram
+    participant UI as UI / Client
+    participant Hub as Hub Provider (OIDC)
+    participant LDAP as LDAP / Active Directory
+    participant ProtectedAPI as Protected API
+    participant DB as Database
+
+    Note over Hub,LDAP: Authentication uses Search + Bind pattern<br>Group retrieval via memberOf (AD) or group search
+
+    %% === Initial Login Flow (Authorization Code Flow) ===
+    UI->>Hub: GET /authorize (client_id, scope=openid profile email, redirect_uri...)
+    Hub-->>UI: Redirect to Hub Login Page
+
+    UI->>Hub: POST Login (username + password)
+    activate Hub
+
+    Hub->>LDAP: 1. Search for user (by sAMAccountName / uid) → get DN
+    LDAP-->>Hub: User DN + basic attributes
+
+    Hub->>LDAP: 2. Bind as user DN with provided password
+    LDAP-->>Hub: Bind Success / Failure
+
+    alt Authentication Failed
+        Hub-->>UI: Login failed → show error
+    else Authentication Succeeded
+        Hub->>LDAP: 3. Fetch groups (memberOf attribute or group search)
+        LDAP-->>Hub: List of group DNs / CNs (e.g. IT-Admins, Finance-Users...)
+
+        Hub->>Hub: Apply YAML group rules (any/and + glob matching)<br>→ Compute internal roles & scopes
+        Hub->>DB: Create / update local user session (optional: store last groups, roles)
+
+        Hub-->>UI: Redirect back with authorization code
+    end
+
+    deactivate Hub
+
+    UI->>Hub: POST /token (grant_type=authorization_code, code=...)
+    activate Hub
+    Hub->>Hub: Validate code + issue tokens
+    Hub-->>UI: Access Token (JWT with roles/scopes) + ID Token + Refresh Token
+    deactivate Hub
+
+    Note over Hub,DB: Access Token contains pre-computed roles/scopes from LDAP groups
+
+    %% === Subsequent API Requests ===
+    UI->>ProtectedAPI: Request with Hub access_token
+    activate ProtectedAPI
+
+    ProtectedAPI->>ProtectedAPI: Verify Hub JWT signature + claims (roles/scopes)
+    ProtectedAPI->>DB: Optional: Lookup user + session metadata
+
+    alt Re-validation / Group Refresh Enabled
+        ProtectedAPI->>Hub: Optional introspection or /userinfo (or direct LDAP check if designed)
+        Hub->>LDAP: Re-fetch current groups (if needed)
+        Hub->>Hub: Re-apply rules → updated roles
+        Hub-->>ProtectedAPI: Updated claims / decision
+    else Simple Mode (no re-validation)
+        ProtectedAPI->>ProtectedAPI: Check local roles/scopes from token
+    end
+
+    alt Access Allowed
+        ProtectedAPI-->>UI: 200 OK + response
+    else Access Denied
+        ProtectedAPI-->>UI: 403 Forbidden
+    end
+
+    deactivate ProtectedAPI
+```
+
+#### Policy
+
+The role mapping policy can be expressed and edit by the UI as simple YAML.
+
+```yaml
+groups:
+- any:
+  - g0 # group name
+  - g1 # group name
+  roles:
+  - r0
+  - r1
+- and:
+  - g2  # group name
+  - g3  # group name
+  roles:
+  - r2
+  - r3
+- any:
+  - dev*  # group name (glob)
+  roles:
+  - dev*  # group name (glob)
+```
+
+
 
 ### Test Plan
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -113,7 +113,7 @@ erDiagram
     TOKEN {
         uint id PK
         uint user_id
-        uint idp_identity_id FK
+        uint idp_identity_id FK nullable
         string jti "jwt id"
         datetime expiration
         datetime revoked

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -39,10 +39,10 @@ Eliminate dependence on Keycloak.
 
 ### Goals
 
+- **To discontinue dependence on keycloak**.
 - To provide AuthZ _out-of-the-box_.
 - To (optionally) delegate authentication to an external OIDC provider
 - To (optionally) delegate authorization to an external OIDC provider.
-- To discontinue dependence on keycloak.
 - To discontinue seeding the realm in keycloak.
 - To support user management in the tackle UI.
   - User CRUD.

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -1,22 +1,14 @@
 ---
 title: neat-enhancement-idea
 authors:
-  - "@janedoe"
+  - "jortel@redhat.com"
 reviewers:
   - TBD
-  - "@alicedoe"
 approvers:
   - TBD
-  - "@oscardoe"
-creation-date: yyyy-mm-dd
-last-updated: yyyy-mm-dd
-status: provisional|implementable|implemented|deferred|rejected|withdrawn|replaced
-see-also:
-  - "/enhancements/this-other-neat-thing.md"  
-replaces:
-  - "/enhancements/that-less-than-great-idea.md"
-superseded-by:
-  - "/enhancements/our-past-effort.md"
+creation-date: 2026-3-27
+last-updated: 2026-3-27
+status: implementable
 ---
 
 # Builtin AuthZ

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -268,81 +268,16 @@ sequenceDiagram
     Note over UI: UI now has tokens issued by the Hub Provider<br>containing both external identity + local authorization (roles/scopes)
 ```
 
-### Login (LDAP)
-
-
-
-### Token Validation
-
-```mermaid
-sequenceDiagram
-    participant UI as UI / API Client
-    participant Hub as Hub Provider<br>(OIDC Provider)
-    participant ProtectedAPI as Protected API / Resource Server
-
-    Note over UI,ProtectedAPI: Token Validation Flow (most common pattern)
-
-    UI->>ProtectedAPI: GET /api/projects<br>Authorization: Bearer <access_token>
-    activate ProtectedAPI
-
-    ProtectedAPI->>ProtectedAPI: 1. Verify JWT Signature<br>(using Hub's JWKS)
-    ProtectedAPI->>ProtectedAPI: 2. Validate Standard Claims<br>(iss, aud, exp, nbf, iat)
-
-    alt Token is Invalid or Expired
-        ProtectedAPI-->>UI: 401 Unauthorized
-    else Token is Valid
-        ProtectedAPI->>ProtectedAPI: 3. Extract Claims<br>(sub, scope, roles if present)
-        ProtectedAPI->>ProtectedAPI: 4. Check Required Scopes<br>e.g. HasScope("api:read") or role-based check
-        alt Authorization Failed
-            ProtectedAPI-->>UI: 403 Forbidden
-        else Authorization Passed
-            ProtectedAPI-->>UI: 200 OK + Response Data
-        end
-    end
-
-    deactivate ProtectedAPI
-
-    Note over ProtectedAPI: Common Validation Order:<br>1. Signature + Issuer<br>2. Expiration<br>3. Audience<br>4. Scopes / Claims<br>5. Custom business rules
-```
-
-### Token validation (external authentication)
-
-```mermaid
-sequenceDiagram
-    participant UI as UI / Client
-    participant Hub as Hub Provider
-    participant ProtectedAPI as Protected API
-    participant DB as Database
-    participant ExternalIdP as External IdP (Google, etc.)
-
-    Note over Hub,DB: During initial login: Store external refresh_token linked to local user
-
-    UI->>ProtectedAPI: Request with Hub access_token
-    activate ProtectedAPI
-
-    ProtectedAPI->>ProtectedAPI: Verify Hub JWT signature + claims
-    ProtectedAPI->>DB: Lookup user + stored external refresh_token
-
-    alt Re-validation Enabled
-        ProtectedAPI->>ExternalIdP: Attempt refresh<br>(POST /token with refresh_token)
-        ExternalIdP-->>ProtectedAPI: Success → new external tokens<br>OR Failure (invalid_grant / revoked)
-        
-        alt External Refresh Failed (Revoked)
-            ProtectedAPI->>ProtectedAPI: Mark session as invalid / force re-login
-            ProtectedAPI-->>UI: 401 Unauthorized + prompt to re-authenticate
-        else External Refresh Succeeded
-            ProtectedAPI->>ProtectedAPI: Optional: Update stored tokens
-            ProtectedAPI->>ProtectedAPI: Check local roles/scopes
-            ProtectedAPI-->>UI: 200 OK
-        end
-    else No Re-validation (simple mode)
-        ProtectedAPI-->>UI: 200 OK (until Hub token expires)
-    end
-
-    deactivate ProtectedAPI
-```
-
 ### LDAP | Activity Directory
+
+TLDR:
+- ODDC (started)
+- Query user using service account.
+- Bind as user. (authentication)
+- Query for group membership.
+- Map groups to roles (and then scopes)
+- OIDC (continued).
+
 
 ```mermaid
 sequenceDiagram
@@ -409,6 +344,76 @@ sequenceDiagram
         ProtectedAPI-->>UI: 200 OK + response
     else Access Denied
         ProtectedAPI-->>UI: 403 Forbidden
+    end
+
+    deactivate ProtectedAPI
+```
+
+### Token Validation
+
+```mermaid
+sequenceDiagram
+    participant UI as UI / API Client
+    participant Hub as Hub Provider<br>(OIDC Provider)
+    participant ProtectedAPI as Protected API / Resource Server
+
+    Note over UI,ProtectedAPI: Token Validation Flow (most common pattern)
+
+    UI->>ProtectedAPI: GET /api/projects<br>Authorization: Bearer <access_token>
+    activate ProtectedAPI
+
+    ProtectedAPI->>ProtectedAPI: 1. Verify JWT Signature<br>(using Hub's JWKS)
+    ProtectedAPI->>ProtectedAPI: 2. Validate Standard Claims<br>(iss, aud, exp, nbf, iat)
+
+    alt Token is Invalid or Expired
+        ProtectedAPI-->>UI: 401 Unauthorized
+    else Token is Valid
+        ProtectedAPI->>ProtectedAPI: 3. Extract Claims<br>(sub, scope, roles if present)
+        ProtectedAPI->>ProtectedAPI: 4. Check Required Scopes<br>e.g. HasScope("api:read") or role-based check
+        alt Authorization Failed
+            ProtectedAPI-->>UI: 403 Forbidden
+        else Authorization Passed
+            ProtectedAPI-->>UI: 200 OK + Response Data
+        end
+    end
+
+    deactivate ProtectedAPI
+
+    Note over ProtectedAPI: Common Validation Order:<br>1. Signature + Issuer<br>2. Expiration<br>3. Audience<br>4. Scopes / Claims<br>5. Custom business rules
+```
+
+### Token validation (external Idp)
+
+```mermaid
+sequenceDiagram
+    participant UI as UI / Client
+    participant Hub as Hub Provider
+    participant ProtectedAPI as Protected API
+    participant DB as Database
+    participant ExternalIdP as External IdP (Google, etc.)
+
+    Note over Hub,DB: During initial login: Store external refresh_token linked to local user
+
+    UI->>ProtectedAPI: Request with Hub access_token
+    activate ProtectedAPI
+
+    ProtectedAPI->>ProtectedAPI: Verify Hub JWT signature + claims
+    ProtectedAPI->>DB: Lookup user + stored external refresh_token
+
+    alt Re-validation Enabled
+        ProtectedAPI->>ExternalIdP: Attempt refresh<br>(POST /token with refresh_token)
+        ExternalIdP-->>ProtectedAPI: Success → new external tokens<br>OR Failure (invalid_grant / revoked)
+        
+        alt External Refresh Failed (Revoked)
+            ProtectedAPI->>ProtectedAPI: Mark session as invalid / force re-login
+            ProtectedAPI-->>UI: 401 Unauthorized + prompt to re-authenticate
+        else External Refresh Succeeded
+            ProtectedAPI->>ProtectedAPI: Optional: Update stored tokens
+            ProtectedAPI->>ProtectedAPI: Check local roles/scopes
+            ProtectedAPI-->>UI: 200 OK
+        end
+    else No Re-validation (simple mode)
+        ProtectedAPI-->>UI: 200 OK (until Hub token expires)
     end
 
     deactivate ProtectedAPI

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -340,7 +340,7 @@ external (federated) IdP.
 
 Currently, Keycloak integration is configured via environment variables in the Hub deployment:
 - `AUTH_REQUIRED` - Enable/disable authentication (e.g., `true`)
-- `KEYCLOAK_HOST` - Keycloak server URL (e.g., `https://keycloak.example.com`)
+- `KEYCLOAK_SERVERL_URL` - Keycloak server URL (e.g., `https://keycloak.example.com`)
 - `KEYCLOAK_REALM` - Realm name (e.g., `konveyor`)
 - `KEYCLOAK_CLIENT_ID` - Client identifier for the Hub (e.g., `tackle-hub`)
 - `KEYCLOAK_CLIENT_SECRET` - Client secret (stored in Secret)

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -48,9 +48,8 @@ Eliminate dependence on Keycloak.
 - To delegate AuthN, AuthZ to an _external_ OIDC provider. (option)
 - To delegate AuthN, AuthZ to an _external_ LDAP, Active Directory with group mapping. (option)
 - To provide RBAC (users, roles, permissions) management in the inventory.
-- To provide for API-Key authentication.  An API-Key is a generated secret used
-  for application integration.
-- To support explicit revocation of both access tokens and API keys for
+- To provide for PAT authentication.  A Personal Access Token (PAT) is a long-lived, opaque token (256 bit hex).
+- To support explicit revocation of both access tokens and PATs for
   immediate credential invalidation.
 
 ### Non-Goals
@@ -71,7 +70,7 @@ organization's existing identity provider (OIDC, LDAP, or Active Directory), so
 that I can enforce centralized authentication policies and maintain a single
 source of truth for user identities.
 
-**As a developer**, I want to use API keys for programmatic access to Konveyor
+**As a developer**, I want to use Personal Access Tokens (PATs) for programmatic access to Konveyor
 APIs, so that I can build automated integrations without managing user
 credentials.
 
@@ -101,7 +100,7 @@ authorization code flow with PKCE. This provider can operate in several modes:
    rules.
 
 The Hub inventory will be extended with new entities for users, roles,
-permissions, tokens, API keys, and external identity mappings. Users are
+permissions, tokens, PATs, and external identity mappings. Users are
 assigned to roles, and roles are associated with permissions (represented as
 OAuth scopes).
 
@@ -160,34 +159,34 @@ Permissions can be scoped broadly (all operations on a resource) or narrowly
 (specific operations on specific sub-resources), supporting both simple and
 complex authorization requirements.
 
-#### API Key Authentication
+#### Personal Access Token (PAT) Authentication
 
-API keys provide a secure mechanism for programmatic access, addressing
+PATs provide a secure mechanism for programmatic access, addressing
 [RFE-266](https://github.com/konveyor/enhancements/issues/266). Users can
-generate API keys through the Hub API, which inherit the user's permissions at
-the time of creation. Keys are presented as Bearer tokens and validated using
+generate PATs through the Hub API, which inherit the user's permissions at
+the time of creation. PATs are presented as Bearer tokens and validated using
 the same scope-based authorization model as JWT tokens.
 
-The task manager and addon API will be refactored to use API keys instead of
+The task manager and addon API will be refactored to use PATs instead of
 custom HMAC-signed JWTs. For backwards compatibility, existing HMAC tokens will
 continue to be honored for in-flight tasks.
 
-API keys support optional expiration dates and can be explicitly revoked through
-the Hub API. The keys themselves are not stored in the database—only
+PATs support optional expiration dates and can be explicitly revoked through
+the Hub API. The tokens themselves are not stored in the database—only
 cryptographic digests—ensuring that compromise of the database does not directly
-expose API keys.
+expose PATs.
 
 #### Tools Integration
 
 Client tools such as **Kantra** and **KAI** should authenticate by getting an
-API-Key.  This is almost exactly like the current process of getting a (JWT)
-token (POST `/auth/login`), the client will POST to a new endpoint that instead
-returns an API-Key. The returned key is specified in future requests using
-authentication header: `Authorization Bearer <key>`.
+PAT.  This is almost exactly like the current process of getting a (JWT)
+token (POST `/auth/token`), the client will POST to a new endpoint that instead
+returns a PAT. The returned token is specified in future requests using
+authentication header: `Authorization Bearer <token>`.
 
 #### Task-Scoped Authentication
 
-API keys can be associated with either users or individual tasks. This enables
+PATs can be associated with either users or individual tasks. This enables
 task-specific authentication where a running task (such as an analysis addon)
 has exactly the permissions it needs for its operation, independent of the user
 who initiated it. This separation improves security by limiting the blast radius
@@ -196,20 +195,20 @@ operations.
 
 #### Credential Lifecycle and Revocation
 
-Both access tokens and API keys support explicit revocation to enable immediate
+Both access tokens and PATs support explicit revocation to enable immediate
 response to security incidents or access changes:
 
-- **API Key Revocation**: API keys can be revoked immediately through the Hub
-  API (`DELETE /auth/apikeys/:id`). Revoked keys are rejected instantly on the
-  next authentication attempt, ensuring compromised keys cannot be used.
+- **Personal Access Token (PAT) Revocation**: PATs can be revoked immediately through the Hub
+  API (`DELETE /auth/tokens/:id`). Revoked tokens are rejected instantly on the
+  next authentication attempt, ensuring compromised tokens cannot be used.
 
 - **Token Revocation**: Access tokens issued via OIDC flows can be revoked
-  through the Hub API (`DELETE /auth/tokens/:id`). Token revocation takes effect
+  through the Hub API (`DELETE /auth/grants/:id`). Token revocation takes effect
   on the next token refresh or when the current access token expires, following
   standard OIDC patterns. Refresh tokens can also be revoked to prevent
   re-authentication.
 
-- **Automatic Expiration**: Both tokens and API keys support configurable
+- **Automatic Expiration**: Both tokens and PATs support configurable
   expiration dates. Expired credentials are automatically rejected without
   requiring explicit revocation.
 
@@ -221,10 +220,10 @@ while maintaining compatibility with OIDC client expectations.
 
 - All sensitive data will be stored securely: passwords as bcrypt hashes,
   refresh tokens encrypted
-- API keys are stored as hashed digests, never in plain text
-- Token validation supports both RSA-signed JWTs (via JWKS) and API keys
+- PATs are stored as hashed digests, never in plain text
+- Token validation supports both RSA-signed JWTs (via JWKS) and PATs
 - HMAC-signed tokens are deprecated but maintained for backwards compatibility
-- Tokens and API keys can be explicitly revoked with immediate (API keys) or
+- Tokens and PATs can be explicitly revoked with immediate (PATs) or
   deferred (tokens on next refresh) effect
 - OIDC clients are configured via operator-managed Secrets rather than stored in
   the database
@@ -255,6 +254,45 @@ The system is designed to adapt to different organizational requirements without
 architectural changes. Deployments can start simple with local authentication
 and evolve to integrate with enterprise identity providers as needs change,
 without requiring migration or re-architecture.
+
+### Operator Changes
+
+The operator will require significant changes to support the Hub's built-in OIDC provider:
+
+#### Hub Configuration
+
+- **Replace Keycloak configuration**: The operator will remove Keycloak-specific configuration from the Hub deployment and replace it with OIDC provider configuration settings
+- **OIDC key signing secret**: The operator must create and manage a Kubernetes Secret containing the RSA private key used by the Hub to sign JWT tokens. This secret will be:
+  - Generated automatically during initial deployment
+  - Mounted into the Hub pod
+  - Rotatable through operator-managed updates
+  - Name: `hub-oidc-signing-key` (or similar)
+  - Format: PEM-encoded RSA private key (minimum 2048-bit)
+
+#### UI Configuration
+
+The UI deployment will be configured to authenticate against the Hub's OIDC provider instead of Keycloak:
+
+- **OIDC client registration**: The operator will configure the UI with OIDC client credentials via ConfigMap or environment variables:
+  - `OIDC_ISSUER`: Points to the Hub's OIDC endpoint (e.g., `https://hub.konveyor.io`)
+  - `OIDC_CLIENT_ID`: Unique identifier for the UI client (e.g., `konveyor-ui`)
+  - `OIDC_CLIENT_SECRET`: Client secret for confidential client authentication (stored in a Secret)
+  - `OIDC_REDIRECT_URI`: Callback URL for the authorization code flow (e.g., `https://ui.konveyor.io/auth/callback`)
+  - `OIDC_SCOPES`: Requested scopes (e.g., `openid profile email`)
+
+#### Client Registration
+
+- The operator will seed the Hub with OIDC client configurations via ConfigMap, including:
+  - UI client definition (client_id, allowed redirect URIs, allowed scopes)
+  - Any additional clients for tools or integrations
+  - This ConfigMap will be mounted into the Hub and read at startup
+
+#### Migration Support
+
+For existing deployments currently using Keycloak:
+- The operator will support a migration mode where Keycloak can be configured as an external OIDC provider
+- A configuration flag or CR annotation will control whether to deploy Keycloak or use the built-in provider
+- Documentation will be provided for migrating users from Keycloak to local Hub authentication
 
 ### Security, Risks, and Mitigations
 
@@ -296,4 +334,10 @@ illustration not approval) including:
 - External provider integration scenarios
 
 ### Upgrade / Downgrade Strategy
+
+Users currently using Keycloak will be converted to the OIDC federated architecture. The keycloak
+will be configured as an _upstream_ IdP.  Users choosing to remove keycloak from the deployment will
+need to import _remote_ users into the hub as _local_ users.  Rather than an upgrade mechanism,
+perhaps a tackle CR flag would enable an option for the UI to prompt the user at the next login
+to create a local user.
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -25,6 +25,8 @@ Add builtin AuthN and AuthZ functionality so that KeyCloak is no longer required
 
 ## Open Questions
 
+- What kinds of authentication options needed to query LDAP.
+
 ## Summary
 
 Currently, keycloak is required to provide user authentication and authorization. Both the Hub

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -29,11 +29,7 @@ Add builtin AuthN and AuthZ functionality so that KeyCloak is no longer required
 
 ## Summary
 
-Currently, keycloak is required to provide user authentication and authorization. Both the Hub
-and the UI integrate with Keycloak using keycloak clients. The goal convert to OIDC (OpenID)
-for AuthZ integration and remove the dependence on keycloak.  Further, to provide an
-internal OIDC provider with optional delegation to an external OIDC provider (such as Keycloak
-but can be anything).
+Currently, Keycloak is required to provide user authentication and authorization. Both the Hub and the UI integrate with Keycloak using Keycloak clients. The goal is to convert to OIDC (OpenID Connect) for authentication and authorization integration and remove the dependence on Keycloak. This will be achieved by providing an internal OIDC provider within the Hub, with optional delegation to external OIDC providers (such as Keycloak, Google, Okta, or others).
 
 ## Motivation
 
@@ -77,11 +73,30 @@ The Hub will implement a standards-compliant OIDC provider supporting the author
 
 3. **LDAP/Active Directory integration**: The Hub authenticates users against LDAP or Active Directory using the standard bind pattern, queries group memberships, and maps groups to local roles using configurable YAML-based rules.
 
-The Hub inventory will be extended with new entities for users, roles, permissions, tokens, API keys, and external identity mappings. Users are assigned to roles, and roles are associated with permissions (represented as OAuth scopes). See [DESIGN.md](./DESIGN.md) for the complete data model.
+The Hub inventory will be extended with new entities for users, roles, permissions, tokens, API keys, and external identity mappings. Users are assigned to roles, and roles are associated with permissions (represented as OAuth scopes).
 
 The UI will be refactored to use OIDC for authentication (replacing the current Keycloak client integration) and will include new pages for managing users, roles, and permissions. The login page will be served from a ConfigMap managed by the operator, enabling branding customization without code changes.
 
 All standard OIDC discovery endpoints will be implemented (`.well-known/openid-configuration`, authorization, token, JWKS, userinfo, introspection, and revocation), allowing any OIDC-compliant client to integrate with the Hub.
+
+#### Default Role Definitions
+
+The system will include predefined roles tailored to common migration project personas (administrators, architects, project managers, migration specialists). These roles provide sensible permission defaults out-of-the-box while remaining fully customizable. Organizations can use these as-is for quick deployments or customize them to match their specific governance requirements.
+
+#### Flexible Role and Permission Management
+
+Role and permission definitions support multiple management approaches to accommodate different operational models:
+- **Operator-managed**: Roles can be defined in configuration files and deployed consistently across environments
+- **UI-managed**: Administrators can create, modify, and delete roles and permissions through the web interface
+- **Hybrid**: Organizations can seed baseline roles via configuration while allowing runtime customization through the UI
+
+This flexibility enables both centralized governance (via operator control) and decentralized administration (via UI self-service).
+
+#### Resource-Based Authorization Model
+
+Authorization is enforced using a resource-and-action permission model. Permissions define what actions (create, read, update, delete) can be performed on which resources (applications, assessments, tasks, etc.). This maps naturally to REST API operations and provides fine-grained access control without requiring administrators to understand OAuth scope syntax.
+
+Permissions can be scoped broadly (all operations on a resource) or narrowly (specific operations on specific sub-resources), supporting both simple and complex authorization requirements.
 
 #### API Key Authentication
 
@@ -90,6 +105,10 @@ API keys provide a secure mechanism for programmatic access, addressing [RFE-266
 The task manager and addon API will be refactored to use API keys instead of custom HMAC-signed JWTs. For backwards compatibility, existing HMAC tokens will continue to be honored for in-flight tasks.
 
 API keys support optional expiration dates and can be explicitly revoked. The keys themselves are not stored in the database—only cryptographic digests—ensuring that compromise of the database does not directly expose API keys.
+
+#### Task-Scoped Authentication
+
+API keys can be associated with either users or individual tasks. This enables task-specific authentication where a running task (such as an analysis addon) has exactly the permissions it needs for its operation, independent of the user who initiated it. This separation improves security by limiting the blast radius of compromised credentials and enables better audit trails for automated operations.
 
 #### Security Considerations
 
@@ -105,6 +124,14 @@ API keys support optional expiration dates and can be explicitly revoked. The ke
 When configured with external providers, the Hub stores refresh tokens (encrypted) to enable ongoing validation. For LDAP/AD integrations, group-to-role mapping is expressed as simple YAML rules supporting both "any" (OR) and "and" (AND) logic, allowing flexible policy definition without code changes.
 
 A README will be published documenting the expected roles and permission scopes catalog to support administrators who want to configure external OIDC providers or Keycloak realms to work with the Hub.
+
+#### Development and Testing Support
+
+The authentication system supports a development mode where authentication can be disabled entirely, simplifying local development and automated testing scenarios. This mode is controlled by configuration and clearly separated from the production authentication path to prevent accidental deployment with authentication disabled.
+
+#### Operational Flexibility
+
+The system is designed to adapt to different organizational requirements without architectural changes. Deployments can start simple with local authentication and evolve to integrate with enterprise identity providers as needs change, without requiring migration or re-architecture.
 
 ### Security, Risks, and Mitigations
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -118,7 +118,7 @@ API keys can be associated with either users or individual tasks. This enables t
 
 #### Security Considerations
 
-- All sensitive data (passwords, refresh tokens) will be stored encrypted
+- All sensitive data will be stored securely: passwords as bcrypt hashes, refresh tokens encrypted
 - API keys are stored as hashed digests, never in plain text
 - Token validation supports both RSA-signed JWTs (via JWKS) and API keys
 - HMAC-signed tokens are deprecated but maintained for backwards compatibility

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -1,5 +1,5 @@
 ---
-title: neat-enhancement-idea
+title: provide builtin AuthZ
 authors:
   - "jortel@redhat.com"
 reviewers:

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -61,8 +61,9 @@ be associated to permissions (scopes).  Tokens will continue to contain scope cl
 
 ```mermaid
 erDiagram
-    USER ||--o{ USER_ROLE : "has many"
-    ROLE ||--o{ USER_ROLE : "belongs to many"
+    USER ||--o{ USER_ROLE : "has"
+    ROLE ||--o{ ROLE_PERMISSION : "has"
+    PERMISSION ||--o{ ROLE_PERMISSION : "is assigned to"
 
     USER {
         uint id PK
@@ -73,13 +74,23 @@ erDiagram
 
     ROLE {
         uint id PK
-        string name "unique (e.g. admin, developer)"
-        string scopes "JSON serialized []string"
+        string name "unique"
+    }
+
+    PERMISSION {
+        uint id PK
+        string name "human readable name"
+        string scope "actual OIDC scope string"
     }
 
     USER_ROLE {
         uint user_id PK,FK
         uint role_id PK,FK
+    }
+
+    ROLE_PERMISSION {
+        uint role_id PK,FK
+        uint permission_id PK,FK
     }
 ```
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -110,7 +110,7 @@ API keys support optional expiration dates and can be explicitly revoked. The ke
 
 Client tools such as **Kantra** and **KAI** should authenticate by getting an API-Key.  This is almost exactly like the current
 process of getting a (JWT) token (POST `/auth/login`), the client will POST to a new endpoint that instead returns an API-Key.
-The returned key is specified in future requests using authentication header: `Authentication Bearer <key>`.
+The returned key is specified in future requests using authentication header: `Authorization Bearer <key>`.
 
 #### Task-Scoped Authentication
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -87,8 +87,8 @@ POST /auth/apikey returns a 256-bit base64-encoded generated key which has been 
 permissions (scopes).
 Returned:
 ```yaml
-ID: uint
-Key: base64-encoded key. (This is the key presented to the API).
+id: uint
+key: base64-encoded key. (This is the key presented to the API).
 ```
 
 #### Revocation

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -44,6 +44,7 @@ Eliminate dependence on Keycloak.
 - To delegate AuthN, AuthZ to an _external_ LDAP, Active Directory with group mapping. (option)
 - To provide RBAC (users, roles, permissions) management in the inventory.
 - To provide for API-Key authentication.  An API-Key is a generated secret used for application integration.
+- To support explicit revocation of both access tokens and API keys for immediate credential invalidation.
 
 ### Non-Goals
 
@@ -108,7 +109,7 @@ API keys provide a secure mechanism for programmatic access, addressing [RFE-266
 
 The task manager and addon API will be refactored to use API keys instead of custom HMAC-signed JWTs. For backwards compatibility, existing HMAC tokens will continue to be honored for in-flight tasks.
 
-API keys support optional expiration dates and can be explicitly revoked. The keys themselves are not stored in the database—only cryptographic digests—ensuring that compromise of the database does not directly expose API keys.
+API keys support optional expiration dates and can be explicitly revoked through the Hub API. The keys themselves are not stored in the database—only cryptographic digests—ensuring that compromise of the database does not directly expose API keys.
 
 #### Tools Integration
 
@@ -119,6 +120,18 @@ The returned key is specified in future requests using authentication header: `A
 #### Task-Scoped Authentication
 
 API keys can be associated with either users or individual tasks. This enables task-specific authentication where a running task (such as an analysis addon) has exactly the permissions it needs for its operation, independent of the user who initiated it. This separation improves security by limiting the blast radius of compromised credentials and enables better audit trails for automated operations.
+
+#### Credential Lifecycle and Revocation
+
+Both access tokens and API keys support explicit revocation to enable immediate response to security incidents or access changes:
+
+- **API Key Revocation**: API keys can be revoked immediately through the Hub API (`DELETE /auth/apikeys/:id`). Revoked keys are rejected instantly on the next authentication attempt, ensuring compromised keys cannot be used.
+
+- **Token Revocation**: Access tokens issued via OIDC flows can be revoked through the Hub API (`DELETE /auth/tokens/:id`). Token revocation takes effect on the next token refresh or when the current access token expires, following standard OIDC patterns. Refresh tokens can also be revoked to prevent re-authentication.
+
+- **Automatic Expiration**: Both tokens and API keys support configurable expiration dates. Expired credentials are automatically rejected without requiring explicit revocation.
+
+This dual-mechanism approach ensures that administrators can quickly respond to security events (compromised credentials, employee departure, role changes) while maintaining compatibility with OIDC client expectations.
 
 #### Security Considerations
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -11,7 +11,7 @@ last-updated: 2026-3-27
 status: implementable
 ---
 
-# Builtin AuthZ
+# Provide builtin AuthZ
 
 Add builtin AuthZ functionality so that KeyCloak is no longer required.
 

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -425,23 +425,25 @@ The role mapping policy can be expressed and edit by the UI as simple YAML.
 
 ```yaml
 groups:
-  # 1. Full Administrators - Broad OR logic (multiple ways to be an admin)
+  # Administrators
   - any:
       - Engineering-Admins
       - Platform-Admins
       - IT-Admins
       - SEC-Global-Admins
+      - Infrastructure-Admins
     roles:
       - admin
 
-  # 2. Managers - Usually requires both department + manager flag
+  # Managers
   - and:
       - Engineering
       - Engineering-Managers
+      - Managers
     roles:
       - manager
 
-  # 3. Architects - Senior technical leadership
+  # Architects
   - any:
       - Engineering-Architects
       - Principal-Architects
@@ -450,38 +452,17 @@ groups:
     roles:
       - architect
 
-  # 4. Migrators - Teams allowed to run data/system migrations
+  # Migrators
   - any:
       - Engineering-Migration-Team
       - Database-Admins
       - SRE-Migration
       - Platform-Migration
+      - Data-Migration-Team
     roles:
       - migrator
 
-  # 5. Development teams - Any dev-related group gets base developer access
-  #    (you can later decide if "developer" should map to one of the above roles or be implicit)
-  - any:
-      - dev*
-      - engineering-*
-      - backend-*
-      - frontend-*
-      - mobile-*
-      - qa*
-      - sre*
-    roles:
-      - developer        # Optional base role - you can remove if not needed
-
-  # 6. Read-only access for support / auditors (common in engineering orgs)
-  - any:
-      - Helpdesk*
-      - IT-Support-RO
-      - Security-Auditors
-      - Compliance-Team
-    roles:
-      - readonly
-
-  # 7. Strict production admin access (example of tighter control)
+  # High-privilege production access
   - and:
       - Engineering
       - Prod-Admins

--- a/enhancements/hub-oidc-provider/README.md
+++ b/enhancements/hub-oidc-provider/README.md
@@ -61,11 +61,11 @@ be associated to permissions (scopes).  Tokens will continue to contain scope cl
 ```mermaid
 sequenceDiagram
     participant UI as UI (Client Application)
-    participant Hub as Hub <br>(OIDC Provider)
+    participant Hub as Hub Provider<br>(OIDC Provider)
     participant User as User
     participant DB as Database<br>(Users + Roles)
 
-    Note over UI,Hub: Authorization Code Flow with Local Authentication
+    Note over UI,Hub: Local Authorization Code Flow (No Consent)
 
     UI->>Hub: GET /oauth2/authorize<br>?client_id=...&scope=openid profile email
     activate Hub
@@ -79,8 +79,6 @@ sequenceDiagram
     Hub->>DB: Authenticate User<br>(check username + password)
     DB-->>Hub: User record + associated Roles
 
-    Hub->>Hub: Validate Credentials
-
     alt Invalid Credentials
         Hub->>User: Show Login Page with Error
         deactivate Hub
@@ -91,19 +89,6 @@ sequenceDiagram
         DB-->>Hub: List of scopes from roles
 
         Hub->>Hub: Apply Authorization Layer<br>(merge requested scopes + role-based scopes)
-
-        alt Consent Required
-            Hub->>User: Show Consent Screen<br>("Allow this app to access ...")
-            User->>Hub: User clicks Approve (or Deny)
-            
-            alt User Denies
-                Hub-->>UI: Redirect with error=access_denied
-            else User Approves
-                Hub->>DB: Save Consent (user + client)
-            end
-        else Consent Already Given
-            Note right of Hub: Skip consent screen
-        end
 
         Hub-->>UI: Redirect back with authorization code
         deactivate Hub


### PR DESCRIPTION
Proposal to eliminate dependence on keycloak.

[README](https://github.com/jortel/enhancements/blob/hub-oidc-provider/hub-oidc-provider/README.md) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive enhancement and design docs for a built-in OIDC authentication system: describes operational modes (local, delegated/broker, LDAP/AD), standard OIDC endpoints and flows, user/role/permission and PAT models, token validation and revocation semantics (including legacy compatibility), credential lifecycle and security/storage expectations, operator configuration and migration guidance from Keycloak, plus testing and upgrade/downgrade plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->